### PR TITLE
Another optimization

### DIFF
--- a/pycvsanaly2/extensions/HunkBlame.py
+++ b/pycvsanaly2/extensions/HunkBlame.py
@@ -215,6 +215,7 @@ class HunkBlame(Blame):
         outer_query = """select distinct h.file_id, h.commit_id
             from hunks h, scmlog s
             where h.commit_id=s.id and s.repository_id=?
+                and s.is_bug_fix=1
                 and h.old_start_line is not null 
                 and h.old_end_line is not null
                 and h.file_id is not null


### PR DESCRIPTION
"There are two optimization I am aware of that could speed up the HunkBlame:
1. As I said in the meeting, we could only blame those bug-fixing hunks, no other
2. Caching the constructed file path. FilePath now queries the database and construct full path of all files in a revision from scratch in each invocation. We can cache the constructed file paths."

These are done in this pull request
