### PR TITLE
Added hard ordering of dependencies

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -82,6 +82,9 @@ Sometimes, a lot of data can pass between CVSAnalY and MySQL, and packet limits 
 
 Follow the instructions [here](http://stackoverflow.com/questions/93128/mysql-got-a-packet-bigger-than-max-allowed-packet-bytes/104176#104176).
 
+### UnicodeEncodeError: 'ascii' codec can't encode character
+This happens because Python is trying to print out a Unicode string to a terminal that has told Python it only supports ASCII. You can co-erce Python into printing Unicode by setting up your [sitecustomize.py](http://diveintopython.org/xml_processing/unicode.html). 
+
 How to get the original CVSAnalY2
 ---------------------------------
 

--- a/pycvsanaly2/Config.py
+++ b/pycvsanaly2/Config.py
@@ -49,8 +49,7 @@ class Config:
                        }
     
     def __init__ (self):
-        for key, value in self.__shared_state.items():
-            self.__dict__[key] = value
+        self.__dict__ = self.__shared_state
         
     def __getattr__ (self, attr):
         return self.__dict__[attr]

--- a/pycvsanaly2/Config.py
+++ b/pycvsanaly2/Config.py
@@ -117,6 +117,10 @@ class Config:
         except:
             pass
         try:
+            self.hard_order = config.hard_order
+        except:
+            pass
+        try:
             self.metrics_all = config.metrics_all
         except:
             pass

--- a/pycvsanaly2/Config.py
+++ b/pycvsanaly2/Config.py
@@ -49,7 +49,8 @@ class Config:
                        }
     
     def __init__ (self):
-        self.__dict__ = self.__shared_state
+        for key, value in self.__shared_state.items():
+            self.__dict__[key] = value
         
     def __getattr__ (self, attr):
         return self.__dict__[attr]

--- a/pycvsanaly2/Config.py
+++ b/pycvsanaly2/Config.py
@@ -44,8 +44,8 @@ class Config:
                        'max_threads' : 10,
                        # Regex for matching bug fixes in BugFixMessage
                        'bug_fix_regexes' : ["defect(s)?", "patch(ing|es|ed)?", "bug(s|fix(es)?)?", 
-                "fix(es|ed)?", "debug(ged)?", "\#\d+", ],
-                       'bug_fix_regexes_case_sensitive' : ["[A-Z]+-\d+",],
+                "(re)?fix(es|ed|ing|age|\s?up(s)?)?", "debug(ged)?", "\#\d+", "back\s?out", "revert(ing|ed)?"],
+                       'bug_fix_regexes_case_sensitive' : ["[A-Z]+(-|#)\d+", "CVE-\d+-\d+"],
                        }
     
     def __init__ (self):

--- a/pycvsanaly2/Config.py
+++ b/pycvsanaly2/Config.py
@@ -37,6 +37,7 @@ class Config:
                        'db_database'   : 'cvsanaly',
                        'db_hostname'   : 'localhost',
                        'extensions'    : [],
+                       'hard_order'    : False,
                        # Metrics extension options
                        'metrics_all'   : False,
                        'metrics_noerr' : False,

--- a/pycvsanaly2/DBContentHandler.py
+++ b/pycvsanaly2/DBContentHandler.py
@@ -652,7 +652,7 @@ class DBContentHandler (ContentHandler):
 
 if __name__ == '__main__':
     import sys
-    from cStringIO import StringIO
+    from io import BytesIO
     from cPickle import dump, load
     from Database import create_database, DBRepository, ICursor
 
@@ -690,7 +690,7 @@ if __name__ == '__main__':
     while rs:
         for t in rs:
             obj = t[0]
-            io = StringIO (obj)
+            io = BytesIO (obj)
             commit = load (io)
             io.close ()
             ch.commit (commit)

--- a/pycvsanaly2/DBTempLog.py
+++ b/pycvsanaly2/DBTempLog.py
@@ -23,7 +23,7 @@ from Repository import Commit
 from AsyncQueue import AsyncQueue, TimeOut
 
 import threading
-from cStringIO import StringIO
+from io import BytesIO
 from cPickle import dump, load
 
 class DBTempLog:
@@ -118,7 +118,7 @@ class DBTempLog:
                 queue.done ()
                 break
 
-            io = StringIO ()
+            io = BytesIO ()
             dump (commit, io, -1)
             obj = io.getvalue ()
             io.close ()
@@ -164,7 +164,7 @@ class DBTempLog:
         while rs:
             for t in rs:
                 obj = t[0]
-                io = StringIO (obj)
+                io = BytesIO (obj)
                 commit = load (io)
                 io.close ()
                 cb (commit)

--- a/pycvsanaly2/Database.py
+++ b/pycvsanaly2/Database.py
@@ -19,7 +19,7 @@
 
 import datetime
 
-from utils import to_utf8, printdbg
+from utils import to_utf8, printdbg, printerr
 
 class DBRepository:
 
@@ -612,6 +612,28 @@ def create_database (driver, database, username = None, password = None, hostnam
         raise e
     
     return db
+
+# Useful DB utility functions
+def execute_statement(statement, parameters, write_cursor, db, error_message, exception=Exception):
+    if isinstance(db, SqliteDatabase):
+        import sqlite3.dbapi2
+        
+        try:
+            write_cursor.execute(statement, parameters)
+        except sqlite3.dbapi2.OperationalError as e:
+            printerr(error_message + ": %s", (e,))
+        except Exception as e:
+            raise exception(e)
+
+    elif isinstance(db, MysqlDatabase):
+        import _mysql_exceptions
+    
+        try:
+            write_cursor.execute(statement, parameters)
+        except _mysql_exceptions.OperationalError as e:
+            printerr(error_message + ": %s", (e,))
+        except Exception as e:
+            raise exception(e)
 
 if __name__ == '__main__':
     db = create_database ('sqlite', '/tmp/foo.db')

--- a/pycvsanaly2/Parser.py
+++ b/pycvsanaly2/Parser.py
@@ -62,13 +62,9 @@ class Parser:
         self.handler.end ()        
     
 if __name__ == '__main__':
-    import sys
-    import os
     from repositoryhandler.backends import create_repository, create_repository_from_path
     from ParserFactory import create_parser_from_logfile, create_parser_from_repository
     from Log import LogReader
-    from Repository import *
-    from utils import *
     
     class StdoutContentHandler (ContentHandler):
         def commit (self, commit):
@@ -80,7 +76,7 @@ if __name__ == '__main__':
                 print "Tags: %s" % (str (commit.tags))
             print "files: "
             for action in commit.actions:
-                print "%s %s " % (action.type, action.f1),
+                print "%s %s " % (action.type, action.f1)
                 if action.f2 is not None:
                     print "(%s: %s) on branch %s" % (action.f2, action.rev, commit.branch or action.branch_f1)
                 else:

--- a/pycvsanaly2/Parser.py
+++ b/pycvsanaly2/Parser.py
@@ -78,7 +78,7 @@ if __name__ == '__main__':
                 print "Author: %s <%s>" % (commit.author.name, commit.author.email)
             if commit.tags is not None:
                 print "Tags: %s" % (str (commit.tags))
-            print "files: ",
+            print "files: "
             for action in commit.actions:
                 print "%s %s " % (action.type, action.f1),
                 if action.f2 is not None:

--- a/pycvsanaly2/Repository.py
+++ b/pycvsanaly2/Repository.py
@@ -156,9 +156,9 @@ if __name__ == '__main__':
     print "rev: %s, committer: %s, date: %s" % (commit.revision, commit.committer, commit.date)
     if commit.author is not None:
         print "Author: %s" % (commit.author)
-    print "files: ",
+    print "files: "
     for action in commit.actions:
-        print "%s %s " % (action.type, action.f1),
+        print "%s %s " % (action.type, action.f1)
         if action.f2 is not None:
             print "(%s: %s) on branch %s" % (action.f2, action.rev, commit.branch or action.branch)
         else:

--- a/pycvsanaly2/extensions/BugFixMessage.py
+++ b/pycvsanaly2/extensions/BugFixMessage.py
@@ -75,10 +75,9 @@ class BugFixMessage(Extension):
     def __match_string(self, regexes, flags, string):
         """Checks whether a string matches a series of regexes"""
         for r in regexes:
-            printdbg("Checking " + str(r))
             # The bit at the beginning and end matches whitespace, punctuation
             # or the start or end of a line.
-            delimiters = "[\s\.,;]"
+            delimiters = "[\s\.,;\!\?\'\"\/\\\]"
             if re.search("(" + delimiters + "+|^)" + r + "(" + delimiters + "+|$)", string, flags):
                 printdbg("[STRING] matched on " + str(r) + " " + string)
                 return True
@@ -86,9 +85,6 @@ class BugFixMessage(Extension):
         return False
 
 
-    # This matches comments about defects, patching, bugs, bugfixes,
-    # fixes, references to bug numbers like #1234, and JIRA style
-    # comments, like HARMONY-1234 or GH-2.
     def fixes_bug(self, commit_message):
         """Check whether a commit message indicated a bug was present.
         
@@ -141,7 +137,35 @@ class BugFixMessage(Extension):
         >>> b.fixes_bug("Found X; debugged and solved.")
         True
         
+        # Regression tests from Apache
+        # When adding these, keep weird punctuation intact.
+        >>> b.fixes_bug("Fixups to build the whole shebang once again.")
+        True
+        >>> b.fixes_bug("Change some INFO messages to DEBUG messages.")
+        True
+        >>> b.fixes_bug("Put back PR#6347")
+        True
+        >>> b.fixes_bug("Typo fixage..")
+        True
+        >>> b.fixes_bug("another typo/fixup")
+        True
+        >>> b.fixes_bug("Refix the entity tag comparisons")
+        True
+        >>> b.fixes_bug("Closeout PR#721")
+        True
+        >>> b.fixes_bug("SECURITY: CVE-2010-0408 (cve.mitre.org)")
+        True
+        >>> b.fixes_bug("    debugged the require_one and require_all")
+        True
+        >>> b.fixes_bug("    various style fixups / general changes")
+        True
+        >>> b.fixes_bug("    Win32: Eliminate useless debug error message")
+        True
+        
         # Things that shouldn't match
+        # Refactoring could go either way, depending on whether you think
+        # renaming/refactoring is a "bug fix." Right now, we don't call that
+        # a "bug"
         >>> b.fixes_bug("Added method print_debug()")
         False
         >>> b.fixes_bug("Altered debug_log()")

--- a/pycvsanaly2/extensions/BugFixMessage.py
+++ b/pycvsanaly2/extensions/BugFixMessage.py
@@ -251,7 +251,7 @@ class BugFixMessage(Extension):
             else:
                 is_bug_fix = 0
 
-            execute_statement(statement(update, db.placeholder), 
+            execute_statement(statement(update, db.place_holder), 
                               (is_bug_fix, row_id), 
                               write_cursor,
                               db,

--- a/pycvsanaly2/extensions/BugFixMessage.py
+++ b/pycvsanaly2/extensions/BugFixMessage.py
@@ -21,7 +21,7 @@ from pycvsanaly2.extensions import Extension, register_extension, \
         ExtensionRunError
 from pycvsanaly2.extensions.FilePaths import FilePaths
 from pycvsanaly2.Database import SqliteDatabase, MysqlDatabase, \
-        TableAlreadyExists, statement
+        TableAlreadyExists, statement, execute_statement
 from pycvsanaly2.utils import printdbg, printerr, printout, \
         remove_directory, uri_to_filename
 from pycvsanaly2.profile import profiler_start, profiler_stop
@@ -251,12 +251,12 @@ class BugFixMessage(Extension):
             else:
                 is_bug_fix = 0
 
-            try:
-                write_cursor.execute(statement(update, db.place_holder), \
-                        (is_bug_fix, row_id))
-            except Exception, e:
-                printerr("Couldn't update scmlog: " + str(e))
-                continue
+            execute_statement(statement(update, db.placeholder), 
+                              (is_bug_fix, row_id), 
+                              write_cursor,
+                              db,
+                              "Couldn't update scmlog",
+                              exception=ExtensionRunError)
 
         read_cursor.close()
         connection.commit()

--- a/pycvsanaly2/extensions/Content.py
+++ b/pycvsanaly2/extensions/Content.py
@@ -28,7 +28,7 @@ from FileRevs import FileRevs
 from repositoryhandler.backends import RepositoryCommandError
 from repositoryhandler.backends.watchers import CAT
 from Jobs import JobPool, Job
-from cStringIO import StringIO
+from io import BytesIO
 import os
 
 # This class holds a single repository retrieve task,
@@ -68,7 +68,7 @@ class ContentJob(Job):
         if ext_ptr != -1:
             suffix = filename[ext_ptr:]
 
-        io = StringIO()
+        io = BytesIO()
 
         wid = self.repo.add_watch(CAT, write_line, io)
         

--- a/pycvsanaly2/extensions/Content.py
+++ b/pycvsanaly2/extensions/Content.py
@@ -172,9 +172,13 @@ class ContentJob(Job):
         >>> cj.file_number_of_lines
         9
         """
-        contents = self.file_contents
-
-        if contents is None:
+        
+        # Access the internal variable to try and get a count even if
+        # Unicode conversion fails
+        
+        try:
+            contents = self._file_contents.strip()
+        except (UnicodeEncodeError, UnicodeDecodeError):
             return None
 
         return len(contents.splitlines())

--- a/pycvsanaly2/extensions/Content.py
+++ b/pycvsanaly2/extensions/Content.py
@@ -133,7 +133,7 @@ class ContentJob(Job):
             # TODO: I should really throw a "not source" exception,
             # but just doing None is fine for now.
             try:
-                return self._file_contents.encode("utf-8").strip()
+                return to_utf8(self._file_contents).strip()
             except:
                 return None
     

--- a/pycvsanaly2/extensions/Content.py
+++ b/pycvsanaly2/extensions/Content.py
@@ -172,8 +172,9 @@ class ContentJob(Job):
                 return None
 
             return len(contents.splitlines())
-
-
+        
+        file_contents = property(get_file_contents)
+        file_number_of_lines = property(get_number_of_lines)
 
 class Content(Extension):
     deps = ['FileTypes']

--- a/pycvsanaly2/extensions/Content.py
+++ b/pycvsanaly2/extensions/Content.py
@@ -121,14 +121,7 @@ class ContentJob(Job):
                 # <http://www.mail-archive.com/bazaar-commits@lists.canonical.com/msg06260.html>
                 #fd.close()
                 pass
-
-        # Returning a value is probably *not* what run does, but we'll just
-        # assume it for now.
-#        print "Before return: %s"%(datetime.now()-start)
-        return self.file_contents
-
-    def get_commit_id(self):
-        return self.commit_id
+                
 
     def get_file_contents(self):
         """Returns contents of the file, stripped of whitespace at either end"""

--- a/pycvsanaly2/extensions/Content.py
+++ b/pycvsanaly2/extensions/Content.py
@@ -136,46 +136,51 @@ class ContentJob(Job):
                 return self._file_contents.encode("utf-8").strip()
             except:
                 return None
-
-
+    
+    def set_file_contents(self, contents):
+        self._file_contents = contents
+        
     def get_number_of_lines(self):
         """Return the number of lines contained within the file, stripped
         of whitespace at either end.
 
+        # Note that it looks like doctest doesn't work with properties,
+        # depending on what your doctest runner is. That's why
+        # it accesses the setter. There's no need to do this in your code.
         >>> cj = ContentJob(None, None, None, None)
-        >>> cj.file_contents = "Hello"
+        >>> cj.set_file_contents("Hello")
         >>> cj.file_number_of_lines
         1
-        >>> cj.file_contents = "Hello \\n world"
+        >>> cj.set_file_contents("Hello \\n world")
         >>> cj.file_number_of_lines
         2
-        >>> cj.file_contents = ""
+        >>> cj.set_file_contents("")
         >>> cj.file_number_of_lines
         0
-        >>> cj.file_contents = None
+        >>> cj.set_file_contents(None)
         >>> cj.file_number_of_lines
 
-        >>> cj.file_contents = "\\n\\n Hello \\n\\n"
+        >>> cj.set_file_contents("\\n\\n Hello \\n\\n")
         >>> cj.file_number_of_lines
         1
 
-        >>> cj.file_contents = "a\\nb"
+        >>> cj.set_file_contents("a\\nb")
         >>> cj.file_number_of_lines
         2
 
-        >>> cj.file_contents = "a\\nb\\nc\\nd\\nea\\nb\\nc\\nd\\ne"
+        >>> cj.set_file_contents("a\\nb\\nc\\nd\\nea\\nb\\nc\\nd\\ne")
         >>> cj.file_number_of_lines
         9
         """
-        contents = self._file_contents
+        contents = self.file_contents
 
         if contents is None:
             return None
 
         return len(contents.splitlines())
     
-    file_contents = property(get_file_contents)
     file_number_of_lines = property(get_number_of_lines)
+    file_contents = property(get_file_contents, set_file_contents)
 
 class Content(Extension):
     deps = ['FileTypes']

--- a/pycvsanaly2/extensions/Content.py
+++ b/pycvsanaly2/extensions/Content.py
@@ -133,7 +133,7 @@ class ContentJob(Job):
             # TODO: I should really throw a "not source" exception,
             # but just doing None is fine for now.
             try:
-                return to_utf8(self._file_contents).strip()
+                return to_utf8(self._file_contents).encode("utf-8").strip()
             except:
                 return None
     

--- a/pycvsanaly2/extensions/Content.py
+++ b/pycvsanaly2/extensions/Content.py
@@ -44,7 +44,7 @@ class ContentJob(Job):
         def write_line (data, io):
             io.write (data)
         
-#        start = datetime.now()
+        # start = datetime.now()
         self.repo = repo
         self.repo_uri = repo_uri
         self.repo_type = self.repo.get_type()
@@ -80,12 +80,12 @@ class ContentJob(Job):
             
         done = False
         failed = False
-#        print "Before downloadning file revision: %s"%(datetime.now()-start)
+        # print "Before downloadning file revision: %s"%(datetime.now()-start)
         # Try downloading the file revision
         while not done and not failed:
             try:
                 self.repo.cat(os.path.join(self.repo_uri, self.path), self.rev)
-#                print "After cat: %s"%(datetime.now()-start)
+                # print "After cat: %s"%(datetime.now()-start)
                 done = True
             except RepositoryCommandError, e:
                 if retries > 0:
@@ -103,7 +103,7 @@ class ContentJob(Job):
                 failed = True
                 printerr("Error obtaining %s@%s. Exception: %s", \
                         (self.path, self.rev, str(e)))
-#        print "After downloadning file revision: %s"%(datetime.now()-start)                
+        #print "After downloadning file revision: %s"%(datetime.now()-start)                
         self.repo.remove_watch(CAT, wid)
 
         if failed:
@@ -123,59 +123,56 @@ class ContentJob(Job):
                 pass
                 
 
-    def get_file_contents(self):
-        """Returns contents of the file, stripped of whitespace at either end"""
-        # An encode will fail if the source code can't be converted to
-        # utf-8, ie. it's not already unicode, or latin-1, or something
-        # obvious. This almost always means that the file isn't source
-        # code at all. 
-        # TODO: I should really throw a "not source" exception,
-        # but just doing None is fine for now.
-        try:
-            return self._file_contents.encode("utf-8").strip()
-        except:
-            return None
-        
-    
-    def get_number_of_lines(self):
-        """Return the number of lines contained within the file, stripped
-        of whitespace at either end.
-        
-        >>> cj = ContentJob(None, None, None, None)
-        >>> cj.file_contents = "Hello"
-        >>> cj.file_number_of_lines
-        1
-        >>> cj.file_contents = "Hello \\n world"
-        >>> cj.file_number_of_lines
-        2
-        >>> cj.file_contents = ""
-        >>> cj.file_number_of_lines
-        0
-        >>> cj.file_contents = None
-        >>> cj.file_number_of_lines
-        
-        >>> cj.file_contents = "\\n\\n Hello \\n\\n"
-        >>> cj.file_number_of_lines
-        1
-        
-        >>> cj.file_contents = "a\\nb"
-        >>> cj.file_number_of_lines
-        2
-        
-        >>> cj.file_contents = "a\\nb\\nc\\nd\\nea\\nb\\nc\\nd\\ne"
-        >>> cj.file_number_of_lines
-        9
-        """
-        contents = self._file_contents
-        
-        if contents is None:
-            return None
-        
-        return len(contents.splitlines())
-    
-    file_contents = property(get_file_contents)
-    file_number_of_lines = property(get_number_of_lines)
-    
+        def get_file_contents(self):
+                """Returns contents of the file, stripped of whitespace at either end"""
+                # An encode will fail if the source code can't be converted to
+                # utf-8, ie. it's not already unicode, or latin-1, or something
+                # obvious. This almost always means that the file isn't source
+                # code at all. 
+                # TODO: I should really throw a "not source" exception,
+                # but just doing None is fine for now.
+                try:
+                    return self._file_contents.encode("utf-8").strip()
+                except:
+                    return None
+
+
+        def get_number_of_lines(self):
+            """Return the number of lines contained within the file, stripped
+            of whitespace at either end.
+
+            >>> cj = ContentJob(None, None, None, None)
+            >>> cj.file_contents = "Hello"
+            >>> cj.file_number_of_lines
+            1
+            >>> cj.file_contents = "Hello \\n world"
+            >>> cj.file_number_of_lines
+            2
+            >>> cj.file_contents = ""
+            >>> cj.file_number_of_lines
+            0
+            >>> cj.file_contents = None
+            >>> cj.file_number_of_lines
+
+            >>> cj.file_contents = "\\n\\n Hello \\n\\n"
+            >>> cj.file_number_of_lines
+            1
+
+            >>> cj.file_contents = "a\\nb"
+            >>> cj.file_number_of_lines
+            2
+
+            >>> cj.file_contents = "a\\nb\\nc\\nd\\nea\\nb\\nc\\nd\\ne"
+            >>> cj.file_number_of_lines
+            9
+            """
+            contents = self._file_contents
+
+            if contents is None:
+                return None
+
+            return len(contents.splitlines())
+
 
 
 class Content(Extension):

--- a/pycvsanaly2/extensions/Content.py
+++ b/pycvsanaly2/extensions/Content.py
@@ -178,7 +178,7 @@ class ContentJob(Job):
         
         try:
             contents = self._file_contents.strip()
-        except (UnicodeEncodeError, UnicodeDecodeError):
+        except (UnicodeEncodeError, UnicodeDecodeError, AttributeError):
             return None
 
         return len(contents.splitlines())

--- a/pycvsanaly2/extensions/HunkBlame.py
+++ b/pycvsanaly2/extensions/HunkBlame.py
@@ -204,7 +204,7 @@ class HunkBlame(Blame):
         if isinstance (self.db, SqliteDatabase):
             import sqlite3.dbapi2
             try:
-                cursor.execute ("""CREATE TABLE _action_files_cache 
+                cursor.execute ("""CREATE TABLE _action_files_cache as
                     select * from action_files""")
             except sqlite3.dbapi2.OperationalError:
                 cursor.close ()
@@ -215,7 +215,7 @@ class HunkBlame(Blame):
             import _mysql_exceptions
 
             try:
-                cursor.execute ("""CREATE TABLE _action_files_cache 
+                cursor.execute ("""CREATE TABLE _action_files_cache as
                     select * from action_files""")
             except _mysql_exceptions.OperationalError, e:
                 if e.args[0] == 1050:

--- a/pycvsanaly2/extensions/HunkBlame.py
+++ b/pycvsanaly2/extensions/HunkBlame.py
@@ -350,7 +350,8 @@ class HunkBlame(Blame):
                 if relative_path is None:
                     raise NotValidHunkWarning("Couldn't find path for file ID %d"%file_id)
                 printdbg ("Path for %d at %s -> %s", (file_id, pre_rev, relative_path))
-                with cnn as inner_cursor:
+                
+                with cnn.cursor() as inner_cursor:
                     inner_query = """select h.id, h.old_start_line, h.old_end_line from hunks h
                         where h.file_id = ? and h.commit_id = ?
                             and h.old_start_line is not null 
@@ -360,6 +361,7 @@ class HunkBlame(Blame):
                     """
                     inner_cursor.execute(statement(inner_query, db.place_holder), (file_id, commit_id))
                     hunks = inner_cursor.fetchall()
+                    
                 hunks = [h for h in hunks if h[0] not in blames]
                 job = HunkBlameJob(hunks, relative_path, pre_rev)
                 

--- a/pycvsanaly2/extensions/HunkBlame.py
+++ b/pycvsanaly2/extensions/HunkBlame.py
@@ -246,7 +246,7 @@ class HunkBlame(Blame):
         """
         cnn = self.db.connect ()
         aux_cursor = cnn.cursor()
-        aux_cursor.execute(statement(query, self.db.place_holder),(file_id))
+        aux_cursor.execute(statement(query, self.db.place_holder),(file_id,))
         all_commits=aux_cursor.fetchall()
         aux_cursor.close()
         cnn.close()

--- a/pycvsanaly2/extensions/HunkBlame.py
+++ b/pycvsanaly2/extensions/HunkBlame.py
@@ -351,7 +351,9 @@ class HunkBlame(Blame):
                     raise NotValidHunkWarning("Couldn't find path for file ID %d"%file_id)
                 printdbg ("Path for %d at %s -> %s", (file_id, pre_rev, relative_path))
                 
-                with cnn.cursor() as inner_cursor:
+                try:
+                    inner_cursor = cnn.cursor()
+                
                     inner_query = """select h.id, h.old_start_line, h.old_end_line from hunks h
                         where h.file_id = ? and h.commit_id = ?
                             and h.old_start_line is not null 
@@ -361,6 +363,9 @@ class HunkBlame(Blame):
                     """
                     inner_cursor.execute(statement(inner_query, db.place_holder), (file_id, commit_id))
                     hunks = inner_cursor.fetchall()
+                #FIXME
+                except Exception as e:
+                    pass
                     
                 hunks = [h for h in hunks if h[0] not in blames]
                 job = HunkBlameJob(hunks, relative_path, pre_rev)

--- a/pycvsanaly2/extensions/Hunks.py
+++ b/pycvsanaly2/extensions/Hunks.py
@@ -20,7 +20,8 @@
 from pycvsanaly2.extensions import Extension, register_extension, \
         ExtensionRunError
 from pycvsanaly2.extensions.FilePaths import FilePaths
-from pycvsanaly2.Database import SqliteDatabase, MysqlDatabase, statement, ICursor
+from pycvsanaly2.Database import SqliteDatabase, MysqlDatabase, statement, \
+    ICursor, execute_statement
 from pycvsanaly2.utils import printdbg, printerr, printout, uri_to_filename
 from pycvsanaly2.profile import profiler_start, profiler_stop
 from pycvsanaly2.PatchParser import parse_patches, RemoveLine, InsertLine, \
@@ -322,14 +323,15 @@ class Hunks(Extension):
                     insert = """insert into hunks(file_id, commit_id,
                                 old_start_line, old_end_line, new_start_line, new_end_line)
                                 values(?,?,?,?,?,?)"""
-                    try:
-                        write_cursor.execute(statement(insert, db.place_holder), \
-                                (file_id, commit_id, hunk.old_start_line, \
-                                hunk.old_end_line, hunk.new_start_line, \
-                                hunk.new_end_line))
-                    except Exception, e:
-                        printerr("Couldn't insert hunk, duplicate record? " + str(e))
-                        continue
+
+                    execute_statement(statement(insert, db.place_holder),
+                                      (file_id, commit_id, hunk.old_start_line, \
+                                       hunk.old_end_line, hunk.new_start_line, \
+                                       hunk.new_end_line),
+                                       write_cursor,
+                                       db,
+                                       "Couldn't insert hunk, duplicate record?",
+                                       exception=ExtensionRunError)
                 
             connection.commit
             rs = icursor.fetchmany()

--- a/pycvsanaly2/extensions/Patches.py
+++ b/pycvsanaly2/extensions/Patches.py
@@ -24,7 +24,7 @@ from pycvsanaly2.Database import (SqliteDatabase, MysqlDatabase, TableAlreadyExi
 from pycvsanaly2.Config import Config
 from pycvsanaly2.extensions import Extension, register_extension, ExtensionRunError
 from pycvsanaly2.utils import to_utf8, printerr, printdbg, uri_to_filename
-from cStringIO import StringIO
+from io import BytesIO
 from Jobs import JobPool, Job
 
 class PatchJob(Job):
@@ -37,7 +37,7 @@ class PatchJob(Job):
         def diff_line (data, io):
             io.write (data)
 
-        io = StringIO ()
+        io = BytesIO ()
         wid = self.repo.add_watch (DIFF, diff_line, io)
         try:
             self.repo.show (self.repo_uri, self.rev)

--- a/pycvsanaly2/main.py
+++ b/pycvsanaly2/main.py
@@ -86,7 +86,7 @@ def main (argv):
     long_opts = ["help", "version", "debug", "quiet", "profile", "config-file=", 
                  "repo-logfile=", "save-logfile=", "no-parse", "db-user=", "db-password=",
                  "db-hostname=", "db-database=", "db-driver=", "extensions=",
-                 "metrics-all", "metrics-noerr"]
+                 "hard-order", "metrics-all", "metrics-noerr"]
 
     # Default options
     debug = None
@@ -104,6 +104,7 @@ def main (argv):
     extensions = None
     metrics_all = None
     metrics_noerr = None
+    hard_order = None
 
     try:
         opts, args = getopt.getopt (argv, short_opts, long_opts)
@@ -144,6 +145,8 @@ def main (argv):
             save_logfile = value
         elif opt in ("--extensions", ):
             extensions = value.split (',')
+        elif opt in ("--hard-order"):
+            hard_order = True
         elif opt in ("--metrics-all", ):
             metrics_all = True
         elif opt in ("--metrics-noerr", ):
@@ -188,6 +191,8 @@ def main (argv):
         config.db_database = database
     if extensions is not None:
         config.extensions.extend ([item for item in extensions if item not in config.extensions])
+    if hard_order is not None:
+        config.hard_order = hard_order
     if metrics_all is not None:
         config.metrics_all = metrics_all
     if metrics_noerr is not None:
@@ -242,7 +247,7 @@ def main (argv):
         # TODO: check parser type == logfile type
 
     try:
-        emg = ExtensionsManager (config.extensions)
+        emg = ExtensionsManager (config.extensions, hard_order=config.hard_order)
     except InvalidExtension, e:
         printerr ("Invalid extension %s", (e.name,))
         return 1

--- a/pycvsanaly2/utils.py
+++ b/pycvsanaly2/utils.py
@@ -57,8 +57,9 @@ def uri_to_filename (uri):
     >>> uri_to_filename("file:///Users/cflewis/Documents")
     '/Users/cflewis/Documents'
     
-    >>> uri_to_filename("~/Documents")
-    '/Users/cflewis/Documents'
+    >>> import os
+    >>> uri_to_filename("~/Documents") == os.path.expanduser("~") + "/Documents"
+    True
     
     """
     if uri_is_remote (uri):

--- a/pycvsanaly2/utils.py
+++ b/pycvsanaly2/utils.py
@@ -28,7 +28,7 @@ config = Config ()
 def to_utf8 (string):
     if isinstance (string, unicode):
         return string.encode ('utf-8')
-    elif isinstance (string, str):
+    elif isinstance (string, bytes):
         for encoding in ['ascii', 'utf-8', 'iso-8859-15']:
             try:
                 s = unicode (string, encoding)

--- a/pycvsanaly2/utils.py
+++ b/pycvsanaly2/utils.py
@@ -27,7 +27,7 @@ config = Config ()
 
 def to_utf8 (string):
     if isinstance (string, unicode):
-        return string.encode ('utf-8')
+        return str(string.encode ('utf-8'))
     elif isinstance (string, bytes):
         for encoding in ['ascii', 'utf-8', 'iso-8859-15']:
             try:
@@ -36,7 +36,7 @@ def to_utf8 (string):
                 continue
             break
 
-        return s.encode ('utf-8')
+        return str(s.encode ('utf-8'))
     else:
         return string
 


### PR DESCRIPTION
Dependencies are sometimes not resolved correctly right now, as described in GH-8.

This provides a workaround so that a hard-ordering can be specified. This has the additional benefits of being able to run an extension independent of its dependencies, if you so wanted.
