### PR TITLE
PULL REQUEST: disable adjacency matrix cache

### DIFF
--- a/pycvsanaly2/extensions/Hunks.py
+++ b/pycvsanaly2/extensions/Hunks.py
@@ -67,7 +67,7 @@ class CommitData:
 # This class holds a single repository retrieve task,
 # and keeps the source code until the object is garbage-collected
 class Hunks(Extension):
-    deps = ['Patches']
+#    deps = ['Patches']
     INTERVAL_SIZE = 100
 
     def __prepare_table(self, connection, drop_table=False):
@@ -274,7 +274,6 @@ class Hunks(Extension):
 
         self.__prepare_table(connection)
         fp = FilePaths(db)
-        fp.update_all(repo_id)
         
         rs = icursor.fetchmany()
 


### PR DESCRIPTION
Now as long as FilePath.update_all is not called, the cache will be disabled automatically, but it also mean that the caller of FilePath needs to iterate over all revisions and call get_path from the first revision to the last.
