### PR TITLE
PULL REQUEST: Changing templog sentinel

### DIFF
--- a/pycvsanaly2/DBTempLog.py
+++ b/pycvsanaly2/DBTempLog.py
@@ -116,7 +116,9 @@ class DBTempLog:
         while True:
             commit = queue.get()
 
-            if not isinstance(commit, Commit):
+            # If we receive a string, assume it's a kill
+            # signal and end
+            if isinstance(commit, str):
                 queue.done()
                 break
 
@@ -185,7 +187,8 @@ class DBTempLog:
         self.queue.join()
         if self.writer_thread.isAlive():
             # Tell the thread to exit
-            # The value doesn't really matter
+            # The value doesn't matter, but it must be
+            # a string
             self.queue.put("END")
             self.writer_thread.join()
 


### PR DESCRIPTION
In DBTempLog, there's a listener that waits for a kill signal on the thread, and if it gets it, it will end. The signal for this is anything that isn't a Commit object. I've been creating Commit objects, but for some reason Python is not detecting that it is a Commit object and killing the queue.

I've changed this so the queue listens for a string instead, and kills the queue that way. This shouldn't change anything about the operation, but the DBTempLog is now more permissive of getting things that aren't commits (which will throw an exception down the line instead).

Asking for code review just to make sure I'm not doing something silly. 
