### PR TITLE
Hunks performance improvement

### DIFF
--- a/pycvsanaly2/Repository.py
+++ b/pycvsanaly2/Repository.py
@@ -106,10 +106,11 @@ class Action:
             self.rev != other.rev
 
     def __repr__(self):
-      return str(self.__dict__)
+        return str(self.__dict__)
 
     def __str__(self):
-      return str(self.__repr__())
+        return str(self.__repr__())
+
 
 class Person:
     def __init__(self):

--- a/pycvsanaly2/main.py
+++ b/pycvsanaly2/main.py
@@ -76,7 +76,8 @@ Options:
       --hard-order               Execute extensions in exactly the order given. 
                                  Won't follow extension dependencies.
       --branch=[branch]          Specify local branch that should be monitored.
-                                 For remote branches add "remote_name/branch_name".
+                                 For remote branches add 
+                                 "remote_name/branch_name".
                                  (only works for Git right now)
       --low-memory               Changes cvsanaly to store certain caches on
                                  the hard drive. This is not well-supported,
@@ -418,6 +419,7 @@ def main(argv):
     # Run extensions
     printout("Executing extensions")
     emg.run_extensions(repo, path or uri, db)
+
     
 def parse_log(uri, repo, parser, reader, config, db):
     # Start the parsing process


### PR DESCRIPTION
I basically followed the procedure I proposed yesterday:

get file name from files table
if the file name is changed in this commit
then use the new file name
If file names equal,
then
    get path
    compare full path
    if full path equal
        make the file found

By taking file rename into account, this scheme worked well with Eclipse JDT Core and jEdit. There are 23954 commits in these projects, 22917 distinct commit_id records in hunks table.
