### PR TITLE
PULL REQUEST: Update classes to be Python 'new-style'

### DIFF
--- a/pycvsanaly2/AsyncQueue.py
+++ b/pycvsanaly2/AsyncQueue.py
@@ -25,7 +25,7 @@ class TimeOut(Exception):
     pass
 
 
-class AsyncQueue:
+class AsyncQueue(object):
 
     def __init__(self, maxsize=0):
         self._init(maxsize)

--- a/pycvsanaly2/Command.py
+++ b/pycvsanaly2/Command.py
@@ -49,7 +49,7 @@ class CommandTimeOut(Exception):
     '''Timeout running command'''
 
 
-class Command:
+class Command(object):
 
     SELECT_TIMEOUT = 2
     

--- a/pycvsanaly2/Config.py
+++ b/pycvsanaly2/Config.py
@@ -25,7 +25,7 @@ class ErrorLoadingConfig(Exception):
         self.message = message
 
 
-class Config:
+class Config(object):
 
     __shared_state = {'debug': False,
                       'quiet': False,

--- a/pycvsanaly2/ContentHandler.py
+++ b/pycvsanaly2/ContentHandler.py
@@ -18,7 +18,7 @@
 #       Carlos Garcia Campos <carlosgc@gsyc.escet.urjc.es>
 
 
-class ContentHandler:
+class ContentHandler(object):
 
     (
         ORDER_REVISION,

--- a/pycvsanaly2/DBDeletionHandler.py
+++ b/pycvsanaly2/DBDeletionHandler.py
@@ -21,7 +21,7 @@ from Database import (execute_statement, get_repo_id, statement, RepoNotFound)
 from utils import printdbg, printout, printerr
 
 
-class DBDeletionHandler:
+class DBDeletionHandler(object):
     """A class for deleting a repository's information from a repository.
     
     FAQ: 

--- a/pycvsanaly2/DBTempLog.py
+++ b/pycvsanaly2/DBTempLog.py
@@ -28,7 +28,7 @@ from io import BytesIO
 from cPickle import dump, load
 
 
-class DBTempLog:
+class DBTempLog(object):
 
     INTERVAL_SIZE = 100
     

--- a/pycvsanaly2/Database.py
+++ b/pycvsanaly2/Database.py
@@ -20,7 +20,7 @@
 from utils import to_utf8, printdbg, printerr
 
 
-class DBRepository:
+class DBRepository(object):
 
     id_counter = 1
 
@@ -41,7 +41,7 @@ class DBRepository:
         self.type = to_utf8(type)
 
 
-class DBLog:
+class DBLog(object):
 
     id_counter = 1
 
@@ -66,7 +66,7 @@ class DBLog:
         self.composed_rev = commit.composed_rev
 
 
-class DBFile:
+class DBFile(object):
 
     id_counter = 1
 
@@ -86,7 +86,7 @@ class DBFile:
         self.repository_id = None
 
 
-class DBFileLink:
+class DBFileLink(object):
     
     id_counter = 1
 
@@ -107,7 +107,7 @@ class DBFileLink:
         self.commit_id = None
 
 
-class DBFilePath:
+class DBFilePath(object):
 
     id_counter = 1
 
@@ -128,7 +128,7 @@ class DBFilePath:
         self.file_path = to_utf8(file_path)
 
 
-class DBPerson:
+class DBPerson(object):
 
     id_counter = 1
 
@@ -148,7 +148,7 @@ class DBPerson:
         self.email = person.email or None
 
 
-class DBBranch:
+class DBBranch(object):
 
     id_counter = 1
 
@@ -166,7 +166,7 @@ class DBBranch:
         self.name = to_utf8(name)
 
        
-class DBAction:
+class DBAction(object):
 
     id_counter = 1
 
@@ -189,7 +189,7 @@ class DBAction:
         self.branch_id = None
 
 
-class DBFileCopy:
+class DBFileCopy(object):
 
     id_counter = 1
 
@@ -214,7 +214,7 @@ class DBFileCopy:
         self.action_id = None
 
 
-class DBTag:
+class DBTag(object):
 
     id_counter = 1
 
@@ -232,7 +232,7 @@ class DBTag:
         self.name = to_utf8(name)
 
 
-class DBTagRev:
+class DBTagRev(object):
 
     id_counter = 1
 
@@ -370,7 +370,7 @@ def statement(str, ph_mark):
     return retval
 
 
-class ICursor:
+class ICursor(object):
 
     def __init__(self, cursor, size=100):
         self.cursor = cursor
@@ -413,7 +413,7 @@ class ICursor:
         self.cursor.close()
 
 
-class Database:
+class Database(object):
     '''CVSAnaly Database'''
 
     place_holder = "?"

--- a/pycvsanaly2/ExtensionsManager.py
+++ b/pycvsanaly2/ExtensionsManager.py
@@ -37,7 +37,7 @@ class InvalidDependency(ExtensionException):
         self.name2 = name2
  
        
-class ExtensionsManager:
+class ExtensionsManager(object):
 
     def __init__(self, exts, hard_order=False):
         self.exts = {}

--- a/pycvsanaly2/GitParser.py
+++ b/pycvsanaly2/GitParser.py
@@ -48,7 +48,7 @@ class GitParser(Parser):
     >>> re.match(p.patterns['commit'], commit) #doctest: +ELLIPSIS
     """
 
-    class GitCommit:
+    class GitCommit(object):
 
         def __init__(self, commit, parents):
             self.commit = commit
@@ -59,7 +59,7 @@ class GitParser(Parser):
             return git_commit.parents and self.commit.revision \
                     in git_commit.parents
 
-    class GitBranch:
+    class GitBranch(object):
 
         (REMOTE, LOCAL, STASH) = range(3)
 

--- a/pycvsanaly2/Log.py
+++ b/pycvsanaly2/Log.py
@@ -27,7 +27,7 @@ class RepoOrLogfileRequired(Exception):
     '''Repository or Logfile is required to read a log'''
 
 
-class LogReader:
+class LogReader(object):
 
     def __init__(self):
         self.logfile = None
@@ -101,7 +101,7 @@ class LogReader:
                     "a repository or a logfile has to be provided")
 
 
-class LogWriter:
+class LogWriter(object):
 
     CHUNK_SIZE = 1024
         

--- a/pycvsanaly2/Parser.py
+++ b/pycvsanaly2/Parser.py
@@ -23,7 +23,7 @@ from ContentHandler import ContentHandler
 from utils import printerr, printout
 
 
-class Parser:
+class Parser(object):
 
     CONTENT_ORDER = ContentHandler.ORDER_REVISION
 

--- a/pycvsanaly2/PatchParser.py
+++ b/pycvsanaly2/PatchParser.py
@@ -131,7 +131,7 @@ def hunk_from_header(line):
     return Hunk(orig_pos, orig_range, mod_pos, mod_range, tail)
 
 
-class HunkLine:
+class HunkLine(object):
     def __init__(self, contents):
         self.contents = contents
 
@@ -184,7 +184,7 @@ def parse_line(line):
         raise MalformedLine("Unknown line type", line)
 
 
-class Hunk:
+class Hunk(object):
     def __init__(self, orig_pos, orig_range, mod_pos, mod_range, tail=None):
         self.orig_pos = orig_pos
         self.orig_range = orig_range

--- a/pycvsanaly2/Repository.py
+++ b/pycvsanaly2/Repository.py
@@ -16,7 +16,7 @@
 #
 
 
-class Commit:
+class Commit(object):
     def __init__(self):
         self.__dict__ = {'revision': None,
                          'committer': None,
@@ -63,7 +63,7 @@ class Commit:
 # V moVed (Renamed)
 # C Copied
 # R Replaced
-class Action:
+class Action(object):
     def __init__(self):
         self.__dict__ = {'type': None,
                          'branch_f1': None,
@@ -112,7 +112,7 @@ class Action:
         return str(self.__repr__())
 
 
-class Person:
+class Person(object):
     def __init__(self):
         self.__dict__ = {'name': None,
                          'email': None}

--- a/pycvsanaly2/Timer.py
+++ b/pycvsanaly2/Timer.py
@@ -19,7 +19,7 @@
 import time
 
 
-class Timer:
+class Timer(object):
 
     def __init__(self):
         self.start()

--- a/pycvsanaly2/extensions/CommitsLOC.py
+++ b/pycvsanaly2/extensions/CommitsLOC.py
@@ -32,7 +32,7 @@ from pycvsanaly2.FindProgram import find_program
 from pycvsanaly2.Command import Command, CommandError
 
 
-class DBCommitLines:
+class DBCommitLines(object):
 
     id_counter = 1
 
@@ -51,7 +51,7 @@ class DBCommitLines:
         self.removed = removed
 
 
-class LineCounter:
+class LineCounter(object):
 
     def __init__(self, repo, uri):
         self.repo = repo

--- a/pycvsanaly2/extensions/FilePaths.py
+++ b/pycvsanaly2/extensions/FilePaths.py
@@ -35,13 +35,13 @@ from time import time
 config = Config()
 
 
-class Adj:
+class Adj(object):
     def __init__(self):
         self.files = {}
         self.adj = {}
 
 
-class FilePaths:
+class FilePaths(object):
     __shared_state = {'rev': None,
                       'adj': None,
                       'files': None,

--- a/pycvsanaly2/extensions/FileRevs.py
+++ b/pycvsanaly2/extensions/FileRevs.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
     sys.path.insert(0, "../../")
 
 
-class FileRevs:
+class FileRevs(object):
 
     INTERVAL_SIZE = 1000
     __query__ = """select s.rev rev, s.id commit_id, af.file_id, 

--- a/pycvsanaly2/extensions/FileTypes.py
+++ b/pycvsanaly2/extensions/FileTypes.py
@@ -25,7 +25,7 @@ from pycvsanaly2.extensions.file_types import guess_file_type
 from pycvsanaly2.utils import to_utf8, uri_to_filename
 
 
-class DBFileType:
+class DBFileType(object):
 
     id_counter = 1
 

--- a/pycvsanaly2/extensions/Hunks.py
+++ b/pycvsanaly2/extensions/Hunks.py
@@ -29,7 +29,7 @@ from pycvsanaly2.PatchParser import parse_patches, RemoveLine, InsertLine, \
 import re
 
 
-class CommitData:
+class CommitData(object):
     def __init__(self, file_name, 
                     old_start_line=None, old_end_line=None, \
                     new_start_line=None, new_end_line=None):

--- a/pycvsanaly2/extensions/Jobs.py
+++ b/pycvsanaly2/extensions/Jobs.py
@@ -82,7 +82,7 @@ class JobPool(object):
         self.queue.join()
 
 
-class Job:
+class Job(object):
     def __init__(self):
         self.failed = False
 

--- a/pycvsanaly2/extensions/Jobs.py
+++ b/pycvsanaly2/extensions/Jobs.py
@@ -26,7 +26,7 @@ import repositoryhandler.backends as rh
 import threading
 
 
-class JobPool:
+class JobPool(object):
 
     POOL_SIZE = 5
 
@@ -82,7 +82,7 @@ class JobPool:
         self.queue.join()
 
 
-class Job:
+class Job(object):
     def __init__(self):
         self.failed = False
 

--- a/pycvsanaly2/extensions/Metrics.py
+++ b/pycvsanaly2/extensions/Metrics.py
@@ -51,7 +51,7 @@ class ProgramNotFound(Extension):
         self.program = program
 
 
-class Measures:
+class Measures(object):
 
     def __init__(self):
         self.__dict__ = {'lang': 'unknown',
@@ -87,7 +87,7 @@ class Measures:
             self.__dict__[key] = -1
 
 
-class FileMetrics:
+class FileMetrics(object):
 
     def __init__(self, path, lang='unknown', sloc=0):
         self.path = path

--- a/pycvsanaly2/extensions/Patches.py
+++ b/pycvsanaly2/extensions/Patches.py
@@ -73,7 +73,7 @@ class PatchJob(Job):
         self.get_patch_for_commit()
 
 
-class DBPatch:
+class DBPatch(object):
 
     id_counter = 1
 

--- a/pycvsanaly2/extensions/__init__.py
+++ b/pycvsanaly2/extensions/__init__.py
@@ -40,7 +40,7 @@ class ExtensionBackoutError(Exception):
     '''Error backing out data created by extension'''
 
 
-class Extension:
+class Extension(object):
 
     deps = []
     

--- a/pycvsanaly2/main.py
+++ b/pycvsanaly2/main.py
@@ -113,6 +113,16 @@ File Count options:
 """
 
 def _parse_log(uri, repo, parser, reader, config, db):
+    """Parse the log with the given parser, outputting to a database.
+
+    Args:
+      uri: The URI of the log to parse (this is already set in the parser)
+      repo: The repositoryhandler repository object to query
+      parser: The parser object that should be started
+      reader: The log reader
+      config: The Config object that specifies the current config
+      db: The database to add the data to
+    """
     # Start the parsing process
     printout("Parsing log for %s (%s)", (uri, repo.get_type()))
 
@@ -136,6 +146,9 @@ def _get_uri_and_repo(path):
 
     This function returns a URI as a string, and the repositoryhandler
     object that represents that URI. They are returned together as a tuple.
+
+    Args:
+      path: The path to the repository
     """
     # Create repository
     if path is not None:

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ import os
 from setuptools import setup
 
 # Utility function to read the README file.
-# Used for the long_description. 
+# Used for the long_description.
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
@@ -37,8 +37,8 @@ setup(
     packages=['pycvsanaly2', 'pycvsanaly2.extensions'],
     long_description=read('README.mdown'),
     scripts = ["cvsanaly2"],
-    install_requires=['repositoryhandler>=0.3.3', 'guilty>=2.0'],
-    dependency_links = ['https://github.com/SoftwareIntrospectionLab/repositoryhandler/tarball/master#egg=repositoryhandler-0.3.2', 
+    install_requires=['repositoryhandler>=0.3.4', 'guilty>=2.0'],
+    dependency_links = ['https://github.com/SoftwareIntrospectionLab/repositoryhandler/tarball/master#egg=repositoryhandler-0.3.4',
     'https://github.com/SoftwareIntrospectionLab/guilty/tarball/master#egg=guilty-2.0'],
     classifiers = [
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
Python classes should always inherit from `object`. This is referred to as 'new-style', but really this was introduced in 2.2, so it's very old now.

If Python classes don't inherit from object, they can display odd behavior, for example things like `__repr__` and `__str__` are not filled in to a sane default without this inheritance.

This request also contains a couple changes which abstract out some functions that I needed to override. They're small enough changes that it isn't worth issuing a new Pull Request.
