### PR TITLE
PULL REQUEST: Change MySQLdb imports

### DIFF
--- a/pycvsanaly2/DBTempLog.py
+++ b/pycvsanaly2/DBTempLog.py
@@ -71,7 +71,7 @@ class DBTempLog(object):
             except:
                 raise
         elif isinstance(self.db, MysqlDatabase):
-            import _mysql_exceptions
+            import MySQLdb
 
             try:
                 cursor.execute("CREATE TABLE _temp_log (" +
@@ -80,7 +80,7 @@ class DBTempLog(object):
                                 "date datetime," +
                                 "object LONGBLOB" +
                                 ") CHARACTER SET=utf8")
-            except _mysql_exceptions.OperationalError, e:
+            except MySQLdb.OperationalError, e:
                 if e.args[0] == 1050:
                     cursor.close()
                     raise TableAlreadyExists

--- a/pycvsanaly2/Database.py
+++ b/pycvsanaly2/Database.py
@@ -562,7 +562,6 @@ class MysqlDatabase(Database):
 
     def connect(self):
         import MySQLdb
-        import _mysql_exceptions
 
         try:
             if self.password is not None:
@@ -572,7 +571,7 @@ class MysqlDatabase(Database):
             else:
                 return MySQLdb.connect(self.hostname, self.username, 
                                        db=self.database, charset='utf8')
-        except _mysql_exceptions.OperationalError, e:
+        except MySQLdb.OperationalError, e:
             if e.args[0] == 1049:
                 raise DatabaseNotFound
             elif e.args[0] == 1045:
@@ -592,7 +591,7 @@ class MysqlDatabase(Database):
         cursor.execute(view)
         
     def create_tables(self, cursor):
-        import _mysql_exceptions
+        import MySQLdb
 
         try:
             cursor.execute("""CREATE TABLE repositories (
@@ -689,7 +688,7 @@ class MysqlDatabase(Database):
                             -- FOREIGN KEY (commit_id) REFERENCES scmlog(id)
                             ) CHARACTER SET=utf8 ENGINE=MyISAM""")
             self._create_views(cursor)
-        except _mysql_exceptions.OperationalError, e:
+        except MySQLdb.OperationalError, e:
             if e.args[0] == 1050:
                 raise TableAlreadyExists
             else:
@@ -754,12 +753,10 @@ def execute_statement(statement, parameters, cursor, db, error_message,
         except Exception as e:
             raise exception(e)
 
-    elif isinstance(db, MysqlDatabase):
-        import _mysql_exceptions
-    
+    elif isinstance(db, MysqlDatabase):    
         try:
             return cursor.execute(statement, parameters)
-        except _mysql_exceptions.OperationalError as e:
+        except MySQLdb.OperationalError as e:
             printerr(error_message + ": %s", (e,))
         except Exception as e:
             raise exception(e)

--- a/pycvsanaly2/extensions/Blame.py
+++ b/pycvsanaly2/extensions/Blame.py
@@ -147,8 +147,8 @@ class Blame(Extension):
             except:
                 raise
         elif isinstance(self.db, MysqlDatabase):
-            import _mysql_exceptions
-
+            import MySQLdb
+            
             try:
                 cursor.execute("""CREATE TABLE blame ("
                                 id integer primary key not null,
@@ -160,7 +160,7 @@ class Blame(Extension):
                                 FOREIGN KEY (commit_id) REFERENCES scmlog(id),
                                 FOREIGN KEY (author_id) REFERENCES people(id)
                                 ) CHARACTER SET=utf8""")
-            except _mysql_exceptions.OperationalError, e:
+            except MySQLdb.OperationalError, e:
                 if e.args[0] == 1050:
                     cursor.close()
                     raise TableAlreadyExists

--- a/pycvsanaly2/extensions/BugFixMessage.py
+++ b/pycvsanaly2/extensions/BugFixMessage.py
@@ -47,8 +47,8 @@ class BugFixMessage(Extension):
                 cursor.close()
 
         elif isinstance(self.db, MysqlDatabase):
-            import _mysql_exceptions
-
+            import MySQLdb
+            
             # I commented out foreign key constraints because
             # cvsanaly uses MyISAM, which doesn't enforce them.
             # MySQL was giving errno:150 when trying to create with
@@ -56,7 +56,7 @@ class BugFixMessage(Extension):
             try:
                 cursor.execute("""ALTER TABLE scmlog
                     ADD is_bug_fix bool default false""")
-            except _mysql_exceptions.OperationalError, e:
+            except MySQLdb.OperationalError, e:
                 if e.args[0] == 1060:
                     # It's OK if the column already exists
                     pass

--- a/pycvsanaly2/extensions/CommitsLOC.py
+++ b/pycvsanaly2/extensions/CommitsLOC.py
@@ -231,7 +231,7 @@ class CommitsLOC(Extension):
             except:
                 raise
         elif isinstance(self.db, MysqlDatabase):
-            import _mysql_exceptions
+            import MySQLdb
 
             try:
                 cursor.execute("""CREATE TABLE commits_lines (
@@ -242,7 +242,7 @@ class CommitsLOC(Extension):
                                 -- FOREIGN KEY (commit_id) 
                                 --    REFERENCES scmlog(id)
                                 ) CHARACTER SET=utf8""")
-            except _mysql_exceptions.OperationalError, e:
+            except MySQLdb.OperationalError, e:
                 if e.args[0] == 1050:
                     cursor.close()
                     raise TableAlreadyExists

--- a/pycvsanaly2/extensions/Content.py
+++ b/pycvsanaly2/extensions/Content.py
@@ -237,7 +237,7 @@ class Content(Extension):
                 cursor.close()
 
         elif isinstance(self.db, MysqlDatabase):
-            import _mysql_exceptions
+            import MySQLdb
 
             cursor = connection.cursor()
             
@@ -259,7 +259,7 @@ class Content(Extension):
                     index(file_id)
                     ) ENGINE=InnoDB CHARACTER SET=utf8""")
 
-            except _mysql_exceptions.OperationalError, e:
+            except MySQLdb.OperationalError, e:
                 if e.args[0] == 1050:
                     # It's OK if the table already exists
                     pass

--- a/pycvsanaly2/extensions/FileCount.py
+++ b/pycvsanaly2/extensions/FileCount.py
@@ -128,7 +128,7 @@ class FileCount(Extension):
                 cursor.close()
 
         elif isinstance(self.db, MysqlDatabase):
-            import _mysql_exceptions
+            import MySQLdb
 
             # I commented out foreign key constraints because
             # cvsanaly uses MyISAM, which doesn't enforce them.
@@ -137,7 +137,7 @@ class FileCount(Extension):
             try:
                 cursor.execute("""ALTER TABLE scmlog
                     ADD file_count int(11)""")
-            except _mysql_exceptions.OperationalError, e:
+            except MySQLdb.OperationalError, e:
                 if e.args[0] == 1060:
                     # It's OK if the column already exists
                     pass

--- a/pycvsanaly2/extensions/FileTypes.py
+++ b/pycvsanaly2/extensions/FileTypes.py
@@ -66,7 +66,7 @@ class FileTypes(Extension):
             except:
                 raise
         elif isinstance(self.db, MysqlDatabase):
-            import _mysql_exceptions
+            import MySQLdb
 
             try:
                 cursor.execute("CREATE TABLE file_types (" +
@@ -75,7 +75,7 @@ class FileTypes(Extension):
                                 "type mediumtext," +
                                 "FOREIGN KEY (file_id) REFERENCES files(id)" +
                                 ") CHARACTER SET=utf8")
-            except _mysql_exceptions.OperationalError, e:
+            except MySQLdb.OperationalError, e:
                 if e.args[0] == 1050:
                     cursor.close()
                     raise TableAlreadyExists

--- a/pycvsanaly2/extensions/HunkBlame.py
+++ b/pycvsanaly2/extensions/HunkBlame.py
@@ -165,7 +165,7 @@ class HunkBlame(Blame):
             except:
                 raise
         elif isinstance(self.db, MysqlDatabase):
-            import _mysql_exceptions
+            import MySQLdb
 
             try:
                 cursor.execute("CREATE TABLE hunk_blames (" +
@@ -173,7 +173,7 @@ class HunkBlame(Blame):
                                 "hunk_id integer REFERENCES hunks(id)," +
                                 "bug_commit_id integer REFERENCES scmlog(id)" +
                                 ") CHARACTER SET=utf8")
-            except _mysql_exceptions.OperationalError, e:
+            except MySQLdb.OperationalError, e:
                 if e.args[0] == 1050:
                     cursor.close()
                     raise TableAlreadyExists
@@ -197,11 +197,11 @@ class HunkBlame(Blame):
             except:
                 raise
         elif isinstance(self.db, MysqlDatabase):
-            import _mysql_exceptions
+            import MySQLdb
 
             try:
                 cursor.execute("drop table _action_files_cache")
-            except _mysql_exceptions.OperationalError, e:
+            except MySQLdb.OperationalError, e:
                 if e.args[0] == 1050:
                     # Do nothing
                     pass
@@ -228,12 +228,12 @@ class HunkBlame(Blame):
             except:
                 raise
         elif isinstance(self.db, MysqlDatabase):
-            import _mysql_exceptions
+            import MySQLdb
 
             try:
                 cursor.execute("""CREATE TABLE _action_files_cache as
                     select * from action_files""")
-            except _mysql_exceptions.OperationalError, e:
+            except MySQLdb.OperationalError, e:
                 if e.args[0] == 1050:
                     cursor.close()
                     raise TableAlreadyExists

--- a/pycvsanaly2/extensions/Hunks.py
+++ b/pycvsanaly2/extensions/Hunks.py
@@ -109,7 +109,7 @@ class Hunks(Extension):
                 cursor.close()
 
         elif isinstance(self.db, MysqlDatabase):
-            import _mysql_exceptions
+            import MySQLdb
 
             # I commented out foreign key constraints because
             # cvsanaly uses MyISAM, which doesn't enforce them.
@@ -129,7 +129,7 @@ class Hunks(Extension):
                     UNIQUE (file_id, commit_id, old_start_line, old_end_line, 
                             new_start_line, new_end_line)
                     ) ENGINE=InnoDB CHARACTER SET=utf8""")
-            except _mysql_exceptions.OperationalError, e:
+            except MySQLdb.OperationalError, e:
                 if e.args[0] == 1050:
                     # It's OK if the table already exists
                     pass

--- a/pycvsanaly2/extensions/Metrics.py
+++ b/pycvsanaly2/extensions/Metrics.py
@@ -774,7 +774,7 @@ class Metrics(Extension):
             except:
                 raise
         elif isinstance(self.db, MysqlDatabase):
-            import _mysql_exceptions
+            import MySQLdb
 
             try:
                 cursor.execute("""CREATE TABLE metrics (
@@ -800,7 +800,7 @@ class Metrics(Extension):
                                 FOREIGN KEY (file_id) REFERENCES tree(id),
                                 FOREIGN KEY (commit_id) REFERENCES scmlog(id)
                                 ) CHARACTER SET=utf8""")
-            except _mysql_exceptions.OperationalError, e:
+            except MySQLdb.OperationalError, e:
                 if e.args[0] == 1050:
                     cursor.close()
                     raise TableAlreadyExists

--- a/pycvsanaly2/extensions/Patches.py
+++ b/pycvsanaly2/extensions/Patches.py
@@ -120,7 +120,7 @@ class Patches(Extension):
             except:
                 raise
         elif isinstance(self.db, MysqlDatabase):
-            import _mysql_exceptions
+            import MySQLdb
 
             try:
                 cursor.execute("""CREATE TABLE patches (
@@ -130,7 +130,7 @@ class Patches(Extension):
                                 -- FOREIGN KEY (commit_id) 
                                 --    REFERENCES scmlog(id)
                                 ) ENGINE=InnoDB, CHARACTER SET=utf8""")
-            except _mysql_exceptions.OperationalError, e:
+            except MySQLdb.OperationalError, e:
                 if e.args[0] == 1050:
                     cursor.close()
                     raise TableAlreadyExists

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def read(fname):
 
 setup(
     name = "cvsanaly",
-    version = "2.3",
+    version = "2.3.1",
     author = "Chris Lewis",
     author_email = "cflewis@soe.ucsc.edu",
     description = ("A Python library for analyzing source control repositories"),


### PR DESCRIPTION
Exceptions for MySQL are being imported from _mysql_exceptions. cvsanaly shouldn't be doing this, these exceptions are exported by MySQLdb. Accessing this hidden module is causing problems with the current deployment venue (and I am surprised we didn't notice any earlier).

This shouldn't really require any thought in the request, as we'll let Jenkins make sure it runs correctly, but I wanted to issue it as a PR so you knew what was happening.
