### PR TITLE
Splitting date into commit_date and author_date

### DIFF
--- a/docs/cvsanaly.mdown
+++ b/docs/cvsanaly.mdown
@@ -180,7 +180,8 @@ The main table is `scmlog`. Every commit in the repository is represented by a r
 * `rev`: The revision identifier in the repository. It's always unique in every repository. 
 * `committer_id`: The identifier in the database of the person who performed the commit.
 * `author_id`: Author identifier. Some source control management systems (only Git at this time), differentiate the person who performed the commit from the person who actually made the changes. When not supported by the repository, this field will be `NULL`.
-* `date`: The date when the commit was performed. 
+* `commit_date`: The date when the commit was performed.
+* `author_date`: The date when the commit was originaly written (only Git at this time). When not supported by the repository, this field will be `NULL`. See author_id.
 * `message`: The commit message. 
 * `composed_rev`: A boolean to indicate whether the rev field is composed or not. This is needed because the rev field must be unique in every repository which is not possible in CVS since it uses revision numbers per file. The combination of a file path and its revision is what make a commit unique in a system like CVS. For this particular case the rev field is represented by the concatenation of the revision number, the pipe character ('|') and the file path. Here is an example for a CVS repository: `1.1.2.1|/poppler/glib/demo/render.c`
 

--- a/pycvsanaly2/BzrParser.py
+++ b/pycvsanaly2/BzrParser.py
@@ -55,7 +55,7 @@ class BzrParser(Parser):
     patterns['commit'] = re.compile("^revno:[ \t]+(.*)$")
     patterns['committer'] = re.compile("^committer:[ \t]+(.*)[ \t]+<(.*)>$")
     patterns['author'] = re.compile("^author:[ \t]+(.*)[ \t]+<(.*)>$")
-    patterns['date'] = re.compile("^timestamp:.* " + \
+    patterns['commit-date'] = re.compile("^timestamp:.* " + \
                             "(\d{4}-\d{2}-\d{2} \d+:\d+:\d+) ([+-]\d{4})$")
     patterns['message'] = re.compile("^message:$")
     patterns['added'] = re.compile("^added:$")
@@ -130,13 +130,13 @@ class BzrParser(Parser):
             return        
 
         # Date
-        match = self.patterns['date'].match(line)
+        match = self.patterns['commit-date'].match(line)
         if match:
-            self.commit.date = datetime.datetime(*(time.strptime
+            self.commit.commit_date = datetime.datetime(*(time.strptime
                                                    (match.group(1).strip(" "), 
                                                     "%Y-%m-%d %H:%M:%S")[0:6]))
             # datetime.datetime.strptime not supported by Python2.4
-            #self.commit.date = datetime.datetime.strptime(\
+            #self.commit.commit_date = datetime.datetime.strptime(\
             #    match.group(1).strip(" "), "%a %b %d %H:%M:%S %Y")
             
             return

--- a/pycvsanaly2/CVSParser.py
+++ b/pycvsanaly2/CVSParser.py
@@ -210,12 +210,12 @@ class CVSParser(Parser):
             commit.committer.name = match.group(8)
             self.handler.committer(commit.committer)
             
-            commit.date = datetime.datetime(int(match.group(1)), 
-                                            int(match.group(2)), 
-                                            int(match.group(3)),
-                                            int(match.group(4)), 
-                                            int(match.group(5)), 
-                                            int(match.group(6)))
+            commit.commit_date = datetime.datetime(int(match.group(1)),
+                                                   int(match.group(2)),
+                                                   int(match.group(3)),
+                                                   int(match.group(4)),
+                                                   int(match.group(5)),
+                                                   int(match.group(6)))
 
             if match.group(10) is not None:
                 self.lines[commit.revision] = (int(match.group(11)), 

--- a/pycvsanaly2/DBContentHandler.py
+++ b/pycvsanaly2/DBContentHandler.py
@@ -171,9 +171,9 @@ class DBContentHandler(ContentHandler):
             profiler_stop("Inserting actions for repository %d",
                           (self.repo_id,))
         if self.commits:
-            commits = [(c.id, c.rev, c.committer, c.author, c.date, \
-                        to_utf8(c.message).decode("utf-8"), c.composed_rev, \
-                        c.repository_id) for c in self.commits]
+            commits = [(c.id, c.rev, c.committer, c.author, c.commit_date, \
+                        c.author_date, to_utf8(c.message).decode("utf-8"), \
+                        c.composed_rev, c.repository_id) for c in self.commits]
             profiler_start("Inserting commits for repository %d",
                            (self.repo_id,))
             cursor.executemany(statement(DBLog.__insert__,

--- a/pycvsanaly2/DBTempLog.py
+++ b/pycvsanaly2/DBTempLog.py
@@ -127,7 +127,7 @@ class DBTempLog(object):
             obj = io.getvalue()
             io.close()
 
-            commits.append((commit.revision, commit.date, 
+            commits.append((commit.revision, commit.commit_date,
                             self.db.to_binary(obj)))
             n_commits += 1
             del commit

--- a/pycvsanaly2/Database.py
+++ b/pycvsanaly2/Database.py
@@ -46,8 +46,8 @@ class DBLog(object):
     id_counter = 1
 
     __insert__ = """INSERT INTO scmlog (id, rev, committer_id, author_id, 
-                    date, message, composed_rev, repository_id) 
-                    values (?, ?, ?, ?, ?, ?, ?, ?)"""
+                    commit_date, author_date, message, composed_rev, repository_id)
+                    values (?, ?, ?, ?, ?, ?, ?, ?, ?)"""
                     
     __delete__ = """DELETE FROM scmlog where repository_id = ?"""
     
@@ -61,7 +61,8 @@ class DBLog(object):
         self.rev = to_utf8(commit.revision)
         self.committer = None
         self.author = None
-        self.date = commit.date
+        self.commit_date = commit.commit_date
+        self.author_date = commit.author_date
         self.message = to_utf8(commit.message)
         self.composed_rev = commit.composed_rev
 
@@ -481,7 +482,8 @@ class SqliteDatabase(Database):
                             rev varchar,
                             committer_id integer,
                             author_id integer,
-                            date datetime,
+                            commit_date datetime,
+                            author_date datetime,
                             message varchar,
                             composed_rev bool, 
                             repository_id integer
@@ -532,7 +534,8 @@ class SqliteDatabase(Database):
                             commit_id integer
                             )""")
             cursor.execute("CREATE index files_file_name on files(file_name)")
-            cursor.execute("CREATE index scmlog_date on scmlog(date)")
+            cursor.execute("CREATE index scmlog_commit_date on scmlog(commit_date)")
+            cursor.execute("CREATE index scmlog_author_date on scmlog(author_date)")
             cursor.execute("CREATE index scmlog_repo on scmlog(repository_id)")
             self._create_views(cursor)
         except sqlite3.dbapi2.OperationalError as e:
@@ -610,7 +613,8 @@ class MysqlDatabase(Database):
                             rev mediumtext,
                             committer_id INT,
                             author_id INT,
-                            date datetime,
+                            commit_date datetime,
+                            author_date datetime,
                             message longtext,
                             composed_rev bool,
                             repository_id INT,
@@ -621,7 +625,8 @@ class MysqlDatabase(Database):
                             -- FOREIGN KEY (repository_id) 
                             --    REFERENCES repositories(id),
                             index(repository_id),
-                            index(date)
+                            index(author_date),
+                            index(commit_date)
                             ) CHARACTER SET=utf8 ENGINE=MyISAM""")
             cursor.execute("""CREATE TABLE files (
                             id INT primary key,

--- a/pycvsanaly2/GitParser.py
+++ b/pycvsanaly2/GitParser.py
@@ -89,16 +89,17 @@ class GitParser(Parser):
                                     "( ([^\(]+))?( \((.*)\))?$")
     patterns['author'] = re.compile("^Author:[ \t]+(.*)[ \t]+<(.*)>$")
     patterns['committer'] = re.compile("^Commit:[ \t]+(.*)[ \t]+<(.*)>$")
-    patterns['date'] = re.compile("^AuthorDate: (.* \d+ \d+:\d+:\d+ \d{4})" + \
-                                  " ([+-]\d{4})$")
+    patterns['commit-date'] = re.compile("^CommitDate: (.* \d+ \d+:\d+:\d+" + \
+                                  " \d{4}) ([+-]\d{4})$")
+    patterns['author-date'] = re.compile("^AuthorDate: (.* \d+ \d+:\d+:\d+" + \
+                                  " \d{4}) ([+-]\d{4})$")
     patterns['file'] = re.compile("^([MAD])[ \t]+(.*)$")
     patterns['file-moved'] = re.compile("^([RC])[0-9]+[ \t]+(.*)[ \t]+(.*)$")
     patterns['branch'] = re.compile("refs/remotes/origin/([^,]*)")
     patterns['local-branch'] = re.compile("refs/heads/([^,]*)")
     patterns['tag'] = re.compile("tag: refs/tags/([^,]*)")
     patterns['stash'] = re.compile("refs/stash")
-    patterns['ignore'] = [re.compile("^CommitDate: .*$"),
-                          re.compile("^Merge: .*$")]
+    patterns['ignore'] = [re.compile("^Merge: .*$")]
     patterns['svn-tag'] = re.compile("^svn path=/tags/(.*)/?; " +
                                      "revision=([0-9]+)$")
 
@@ -273,15 +274,20 @@ class GitParser(Parser):
 
             return
 
-        # Date
-        match = self.patterns['date'].match(line)
+        # Commit Date
+        match = self.patterns['commit-date'].match(line)
         if match:
-            self.commit.date = datetime.datetime(*(time.strptime(\
+            self.commit.commit_date = datetime.datetime(*(time.strptime(\
                 match.group(1).strip(" "), "%a %b %d %H:%M:%S %Y")[0:6]))
-            # datetime.datetime.strptime not supported by Python2.4
-            #self.commit.date = datetime.datetime.strptime(\
-            #    match.group(1).strip(" "), "%a %b %d %H:%M:%S %Y")
-            
+
+            return
+
+        # Author Date
+        match = self.patterns['author-date'].match(line)
+        if match:
+            self.commit.author_date = datetime.datetime(*(time.strptime(\
+                match.group(1).strip(" "), "%a %b %d %H:%M:%S %Y")[0:6]))
+
             return
 
         # File

--- a/pycvsanaly2/Parser.py
+++ b/pycvsanaly2/Parser.py
@@ -74,7 +74,7 @@ if __name__ == '__main__':
             print "Commit"
             print "rev: %s, committer: %s <%s>, date: %s" % \
                 (commit.revision, commit.committer.name, 
-                 commit.committer.email, commit.date)
+                 commit.committer.email, commit.commit_date)
             if commit.author is not None:
                 print "Author: %s <%s>" % (commit.author.name, 
                                            commit.author.email)

--- a/pycvsanaly2/Repository.py
+++ b/pycvsanaly2/Repository.py
@@ -21,7 +21,8 @@ class Commit(object):
         self.__dict__ = {'revision': None,
                          'committer': None,
                          'author': None,
-                         'date': None,
+                         'commit_date': None,
+                         'author_date': None,
                          'actions': [],
                          'branch': None,
                          'tags': None,
@@ -151,7 +152,8 @@ if __name__ == '__main__':
     c = Commit()
     c.revision = '25'
     c.committer = 'carlosgc'
-    c.date = datetime.datetime.now()
+    c.commit_date = datetime.datetime.now()
+    c.author_date = datetime.datetime.now()
     c.message = "Modified foo files"
 
     for i in range(5):
@@ -173,7 +175,7 @@ if __name__ == '__main__':
 
     print "Commit"
     print "rev: %s, committer: %s, date: %s" % (commit.revision,
-                                                commit.committer, commit.date)
+                                                commit.committer, commit.commit_date)
     if commit.author is not None:
         print "Author: %s" % (commit.author)
     print "files: "

--- a/pycvsanaly2/SVNParser.py
+++ b/pycvsanaly2/SVNParser.py
@@ -235,12 +235,12 @@ class SVNParser(Parser):
             commit.committer = Person()
             commit.committer.name = match.group(2)
             
-            commit.date = datetime.datetime(int(match.group(3)), 
-                                            int(match.group(4)), 
-                                            int(match.group(5)),
-                                            int(match.group(6)), 
-                                            int(match.group(7)), 
-                                            int(match.group(8)))
+            commit.commit_date = datetime.datetime(int(match.group(3)),
+                                                   int(match.group(4)),
+                                                   int(match.group(5)),
+                                                   int(match.group(6)),
+                                                   int(match.group(7)),
+                                                   int(match.group(8)))
             self.msg_lines = int(match.group(10))
             self.commit = commit
             self.handler.committer(commit.committer)

--- a/pycvsanaly2/extensions/FilePaths.py
+++ b/pycvsanaly2/extensions/FilePaths.py
@@ -277,7 +277,7 @@ class FilePaths(object):
         cursor = cnn.cursor()
         query = """select distinct(s.id) from scmlog s, actions a
                     where s.id = a.commit_id and repository_id=?
-                    order by s.date"""
+                    order by s.commit_date"""
         cursor.execute(statement(query, db.place_holder), (repo_id,))
         
         old_id = -1

--- a/pycvsanaly2/extensions/FileRevs.py
+++ b/pycvsanaly2/extensions/FileRevs.py
@@ -28,11 +28,11 @@ if __name__ == '__main__':
 class FileRevs(object):
 
     INTERVAL_SIZE = 1000
-    __query__ = """select s.rev rev, s.id commit_id, af.file_id, 
-        af.action_type, s.composed_rev 
-        from scmlog s, action_files af 
-        where s.id = af.commit_id and s.repository_id = ? 
-        order by s.date"""
+    __query__ = """select s.rev rev, s.id commit_id, af.file_id,
+        af.action_type, s.composed_rev
+        from scmlog s, action_files af
+        where s.id = af.commit_id and s.repository_id = ?
+        order by s.commit_date"""
 
     def __init__(self, db, cnn, cursor, repoid):
         self.db = db

--- a/pycvsanaly2/extensions/Patches.py
+++ b/pycvsanaly2/extensions/Patches.py
@@ -21,6 +21,7 @@ from repositoryhandler.backends.watchers import DIFF
 from repositoryhandler.Command import CommandError, CommandRunningError
 from pycvsanaly2.Database import (SqliteDatabase, MysqlDatabase, 
         TableAlreadyExists, statement, ICursor, execute_statement)
+from pycvsanaly2.profile import profiler_start, profiler_stop
 from pycvsanaly2.Config import Config
 from pycvsanaly2.extensions import (Extension, register_extension, 
     ExtensionRunError)
@@ -68,9 +69,11 @@ class PatchJob(Job):
         return self.data
 
     def run(self, repo, repo_uri):
+        profiler_start("Processing patch for revision %s", (self.rev))
         self.repo = repo
         self.repo_uri = repo_uri
         self.get_patch_for_commit()
+        profiler_stop("Processing patch for revision %s", (self.rev))
 
 
 class DBPatch(object):
@@ -170,6 +173,7 @@ class Patches(Extension):
             finished_job = job_pool.get_next_done(0)
 
     def run(self, repo, uri, db):
+        profiler_start("Running Patches extension")
         self.db = db
         self.repo = repo
 
@@ -249,6 +253,7 @@ class Patches(Extension):
         write_cursor.close()
         cursor.close()
         cnn.close()
+        profiler_stop("Running Patches extension", delete=True)
         
     def backout(self, repo, uri, db):
         update_statement = """delete from patches


### PR DESCRIPTION
The table `scmlog` gives the option for `committer_id` and `author_id`, but NOT for both dates. So I split the `date` field into `commit_date` (identical to the "old" date) and `author_date`.

This should work with all extentions and also with SQLite. But no garante that is't working with SQLite, since I only tested it with MySQL.

This is (so far) a GIT only feature.

Added also some profiling information to the extension `Patches`.
