### PR TITLE
Optionally count git merges

### DIFF
--- a/pycvsanaly2/Config.py
+++ b/pycvsanaly2/Config.py
@@ -61,8 +61,8 @@ class Config(object):
                                           "revert(ing|ed)?"],
                       'bug_fix_regexes_case_sensitive': ["[A-Z]+(-|#)\d+",
                                                          "CVE-\d+-\d+"],
-                      # Should merge commits be analysed.
-                      'analyse_merges': False,
+                      # Should merge commits be analyzed.
+                      'analyze_merges': False,
                      }
 
     def __init__(self):
@@ -182,7 +182,7 @@ class Config(object):
         except:
             pass
         try:
-            self.analyse_merges = config.analyse_merges
+            self.analyze_merges = config.analyze_merges
         except:
             pass
 

--- a/pycvsanaly2/Config.py
+++ b/pycvsanaly2/Config.py
@@ -61,7 +61,9 @@ class Config(object):
                                           "revert(ing|ed)?"],
                       'bug_fix_regexes_case_sensitive': ["[A-Z]+(-|#)\d+",
                                                          "CVE-\d+-\d+"],
-                       }
+                      # Should merge commits be analysed.
+                      'analyse_merges': False,
+                     }
 
     def __init__(self):
         self.__dict__ = self.__shared_state
@@ -177,6 +179,10 @@ class Config(object):
 
         try:
             self.backout = config.backout
+        except:
+            pass
+        try:
+            self.analyse_merges = config.analyse_merges
         except:
             pass
 

--- a/pycvsanaly2/GitParser.py
+++ b/pycvsanaly2/GitParser.py
@@ -247,7 +247,7 @@ class GitParser(Parser):
             else:
                 self.branch.set_tail(git_commit)
             
-            if parents and len(parents) > 1 and not Config().analyse_merges:
+            if parents and len(parents) > 1 and not Config().analyze_merges:
                 #Skip merge commits
                 self.commit = None
             

--- a/pycvsanaly2/GitParser.py
+++ b/pycvsanaly2/GitParser.py
@@ -247,12 +247,14 @@ class GitParser(Parser):
             else:
                 self.branch.set_tail(git_commit)
             
-            if parents and len(parents) > 1:
+            if parents and len(parents) > 1 and not Config().analyse_merges:
                 #Skip merge commits
                 self.commit = None
+            
             return
         elif self.commit is None:
             return
+        
         # Committer
         match = self.patterns['committer'].match(line)
         if match:

--- a/pycvsanaly2/main.py
+++ b/pycvsanaly2/main.py
@@ -86,7 +86,7 @@ Options:
                                  slower, as it is not caching in memory, and
                                  is somewhat paranoid about the integrity of
                                  the on-disk cache, so will often empty it.
-      --analyse-merges           Tells cvsanaly to also parse merge commits.
+      --analyze-merges           Tells cvsanaly to also parse merge commits.
                                  The default is to skip them.
 
 Database:
@@ -209,7 +209,7 @@ def main(argv):
                  "no-parse", "db-user=", "db-password=", "db-hostname=",
                  "db-database=", "db-driver=", "extensions=", "hard-order",
                  "metrics-all", "metrics-noerr", "no-content", "branch=",
-                 "backout", "low-memory", "count-types=", "analyse-merges"]
+                 "backout", "low-memory", "count-types=", "analyze-merges"]
 
     # Default options
     debug = None
@@ -233,7 +233,7 @@ def main(argv):
     branch = None
     backout = None
     count_types = None
-    analyse_merges = None
+    analyze_merges = None
 
     try:
         opts, args = getopt.getopt(argv, short_opts, long_opts)
@@ -290,8 +290,8 @@ def main(argv):
             no_content = True
         elif opt in ("-b", "--backout"):
             backout = True
-        elif opt in ("--analyse-merges"):
-            analyse_merges = True
+        elif opt in ("--analyze-merges"):
+            analyze_merges = True
 
     if len(args) <= 0:
         uri = os.getcwd()
@@ -350,8 +350,8 @@ def main(argv):
         config.no_content = no_content
     if backout is not None:
         config.extensions = get_all_extensions()
-    if analyse_merges is not None:
-        config.analyse_merges = analyse_merges
+    if analyze_merges is not None:
+        config.analyze_merges = analyze_merges
 
     if not config.extensions and config.no_parse:
         # Do nothing!!!

--- a/pycvsanaly2/main.py
+++ b/pycvsanaly2/main.py
@@ -86,6 +86,8 @@ Options:
                                  slower, as it is not caching in memory, and
                                  is somewhat paranoid about the integrity of
                                  the on-disk cache, so will often empty it.
+      --analyse-merges           Tells cvsanaly to also parse merge commits.
+                                 The default is to skip them.
 
 Database:
 
@@ -207,7 +209,7 @@ def main(argv):
                  "no-parse", "db-user=", "db-password=", "db-hostname=",
                  "db-database=", "db-driver=", "extensions=", "hard-order",
                  "metrics-all", "metrics-noerr", "no-content", "branch=",
-                 "backout", "low-memory", "count-types="]
+                 "backout", "low-memory", "count-types=", "analyse-merges"]
 
     # Default options
     debug = None
@@ -231,6 +233,7 @@ def main(argv):
     branch = None
     backout = None
     count_types = None
+    analyse_merges = None
 
     try:
         opts, args = getopt.getopt(argv, short_opts, long_opts)
@@ -287,6 +290,8 @@ def main(argv):
             no_content = True
         elif opt in ("-b", "--backout"):
             backout = True
+        elif opt in ("--analyse-merges"):
+            analyse_merges = True
 
     if len(args) <= 0:
         uri = os.getcwd()
@@ -345,6 +350,8 @@ def main(argv):
         config.no_content = no_content
     if backout is not None:
         config.extensions = get_all_extensions()
+    if analyse_merges is not None:
+        config.analyse_merges = analyse_merges
 
     if not config.extensions and config.no_parse:
         # Do nothing!!!

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     packages=['pycvsanaly2', 'pycvsanaly2.extensions'],
     long_description=read('README.mdown'),
     scripts = ["cvsanaly2"],
-    install_requires=['repositoryhandler>=0.3.4', 'guilty>=2.0'],
+    install_requires=['repositoryhandler>=0.3.5', 'guilty>=2.0'],
     dependency_links = ['https://github.com/SoftwareIntrospectionLab/repositoryhandler/tarball/master#egg=repositoryhandler-0.3.4',
     'https://github.com/SoftwareIntrospectionLab/guilty/tarball/master#egg=guilty-2.0'],
     classifiers = [


### PR DESCRIPTION
- added config option 'analyse_merges'.
- The default is False.
- Bumped version number of repositoryhandler since modified behavior is needed (see  https://github.com/SoftwareIntrospectionLab/repositoryhandler/pull/7 ).
