### PR TITLE
PULL REQUEST: PatchesAndHunks extension

### DIFF
--- a/pycvsanaly2/BzrParser.py
+++ b/pycvsanaly2/BzrParser.py
@@ -29,16 +29,16 @@ from Repository import Commit, Action, Person
 #       Branches stuff
 class BzrParser(Parser):
     """A parser for Bazaar.
-    
+
     # These are a couple of tests for the longer regexes that had
     # to be split up when trying to get PEP-8 line length compliance
     >>> p = BzrParser()
     >>> ts = "timestamp: Mon 2010-12-27 02:39:12 +0000"
-    >>> re.match(p.patterns['date'], ts) #doctest: +ELLIPSIS
+    >>> re.match(p.patterns['commit-date'], ts) #doctest: +ELLIPSIS
     <_sre.SRE_Match object...>
     >>> ts = "timestamp: Mon 2010-12-27 02:39:12+0000"
-    >>> re.match(p.patterns['date'], ts) #doctest: +ELLIPSIS
-    
+    >>> re.match(p.patterns['commit-date'], ts) #doctest: +ELLIPSIS
+
     """
 
     (
@@ -50,7 +50,7 @@ class BzrParser(Parser):
         REMOVED,
         RENAMED
     ) = range(7)
-    
+
     patterns = {}
     patterns['commit'] = re.compile("^revno:[ \t]+(.*)$")
     patterns['committer'] = re.compile("^committer:[ \t]+(.*)[ \t]+<(.*)>$")
@@ -79,7 +79,7 @@ class BzrParser(Parser):
         self.handler.commit(self.commit)
         self.commit = None
         self.state = BzrParser.COMMIT
-        
+
     def _parse_line(self, line):
         if line is None or line == '':
             return
@@ -97,14 +97,14 @@ class BzrParser(Parser):
             self.state = BzrParser.UNKNOWN
 
             return
-        
+
         # Commit
         match = self.patterns['commit'].match(line)
         if match:
             self.flush()
             self.commit = Commit()
             self.commit.revision = match.group(1)
-            
+
             self.state = BzrParser.COMMIT
 
             return
@@ -127,18 +127,18 @@ class BzrParser(Parser):
             self.commit.author.email = match.group(2)
             self.handler.author(self.commit.author)
 
-            return        
+            return
 
         # Date
         match = self.patterns['commit-date'].match(line)
         if match:
             self.commit.commit_date = datetime.datetime(*(time.strptime
-                                                   (match.group(1).strip(" "), 
+                                                   (match.group(1).strip(" "),
                                                     "%Y-%m-%d %H:%M:%S")[0:6]))
             # datetime.datetime.strptime not supported by Python2.4
             #self.commit.commit_date = datetime.datetime.strptime(\
             #    match.group(1).strip(" "), "%a %b %d %H:%M:%S %Y")
-            
+
             return
 
         # Message
@@ -147,7 +147,7 @@ class BzrParser(Parser):
             self.state = BzrParser.MESSAGE
 
             return
-        
+
         # Added files
         match = self.patterns['added'].match(line)
         if match:
@@ -201,7 +201,7 @@ class BzrParser(Parser):
             action.type = 'V'
             action.f1 = m.group(2)
             action.f2 = m.group(1)
-            
+
             self.commit.actions.append(action)
             self.handler.file(action.f1)
         else:

--- a/pycvsanaly2/GitParser.py
+++ b/pycvsanaly2/GitParser.py
@@ -29,16 +29,16 @@ from Config import Config
 
 class GitParser(Parser):
     """A parser for Git.
-    
+
     # These are a couple of tests for the longer regexes that had
     # to be split up when trying to get PEP-8 line length compliance
     >>> p = GitParser()
     >>> date = "AuthorDate: Wed Jan 12 17:17:30 2011 -0800"
-    >>> re.match(p.patterns['date'], date) #doctest: +ELLIPSIS
+    >>> re.match(p.patterns['commit-date'], date) #doctest: +ELLIPSIS
     <_sre.SRE_Match object...>
     >>> date = "AuthorDate: Wed Jan 12 17:17:30 2011-0800"
-    >>> re.match(p.patterns['date'], date) #doctest: +ELLIPSIS
-    
+    >>> re.match(p.patterns['commit-date'], date) #doctest: +ELLIPSIS
+
     >>> commit = "".join(["commit d254e04dd51c3cac8cdc3355b4514a40c7a0baed ", \
         "ffb98f1c47114c33e8c77c107fbd2e15848b2537 ", \
         "(refs/remotes/origin/li-r1104)"])
@@ -115,7 +115,7 @@ class GitParser(Parser):
 
     def set_repository(self, repo, uri):
         Parser.set_repository(self, repo, uri)
-        self.is_gnome = re.search("^[a-z]+://(.*@)?git\.gnome\.org/.*$", 
+        self.is_gnome = re.search("^[a-z]+://(.*@)?git\.gnome\.org/.*$",
                                   repo.get_uri()) is not None
 
     def flush(self):
@@ -132,7 +132,7 @@ class GitParser(Parser):
         for patt in self.patterns['ignore']:
             if patt.match(line):
                 return
-        
+
         # Commit
         match = self.patterns['commit'].match(line)
         if match:
@@ -153,8 +153,8 @@ class GitParser(Parser):
             # won't be any decoration, so a branch needs to be
             # created
             if Config().branch is not None:
-                self.branch = self.GitBranch(self.GitBranch.LOCAL, 
-                                             Config().branch, 
+                self.branch = self.GitBranch(self.GitBranch.LOCAL,
+                                             Config().branch,
                                              git_commit)
 
             decorate = match.group(5)
@@ -163,38 +163,38 @@ class GitParser(Parser):
                 # Remote branch
                 m = re.search(self.patterns['branch'], decorate)
                 if m:
-                    branch = self.GitBranch(self.GitBranch.REMOTE, m.group(1), 
+                    branch = self.GitBranch(self.GitBranch.REMOTE, m.group(1),
                                             git_commit)
-                    printdbg("Branch '%s' head at acommit %s", 
+                    printdbg("Branch '%s' head at acommit %s",
                              (branch.name, self.commit.revision))
                 else:
                     # Local Branch
                     m = re.search(self.patterns['local-branch'], decorate)
                     if m:
-                        branch = self.GitBranch(self.GitBranch.LOCAL, 
+                        branch = self.GitBranch(self.GitBranch.LOCAL,
                                                 m.group(1), git_commit)
-                        printdbg("Commit %s on local branch '%s'", 
+                        printdbg("Commit %s on local branch '%s'",
                                  (self.commit.revision, branch.name))
-                        # If local branch was merged we just ignore this 
+                        # If local branch was merged we just ignore this
                         # decoration
                         if self.branch and \
                         self.branch.is_my_parent(git_commit):
-                            printdbg("Local branch '%s' was merged", 
+                            printdbg("Local branch '%s' was merged",
                                      (branch.name,))
                             branch = None
                     else:
                         # Stash
                         m = re.search(self.patterns['stash'], decorate)
                         if m:
-                            branch = self.GitBranch(self.GitBranch.STASH, 
+                            branch = self.GitBranch(self.GitBranch.STASH,
                                                     "stash", git_commit)
-                            printdbg("Commit %s on stash", 
+                            printdbg("Commit %s on stash",
                                      (self.commit.revision,))
                 # Tag
                 m = re.search(self.patterns['tag'], decorate)
                 if m:
                     self.commit.tags = [m.group(1)]
-                    printdbg("Commit %s tagged as '%s'", 
+                    printdbg("Commit %s tagged as '%s'",
                              (self.commit.revision, self.commit.tags[0]))
 
             if branch is not None and self.branch is not None:
@@ -218,7 +218,7 @@ class GitParser(Parser):
                     if b.is_my_parent(git_commit):
                         # We assume current branch is always the last one
                         # AFAIK there's no way to make sure this is right
-                        printdbg("Start point of branch '%s' at commit %s", 
+                        printdbg("Start point of branch '%s' at commit %s",
                                  (self.branches[0].name, self.commit.revision))
                         self.branches.pop(0)
                         self.branch = b
@@ -228,7 +228,7 @@ class GitParser(Parser):
                 # There's a pending tag in previous commit
                 pending_tag = self.branch.tail.svn_tag
                 printdbg("Move pending tag '%s' from previous commit %s " + \
-                         "to current %s", (pending_tag, 
+                         "to current %s", (pending_tag,
                                            self.branch.tail.commit.revision,
                                            self.commit.revision))
                 if self.commit.tags and pending_tag not in self.commit.tags:
@@ -247,15 +247,15 @@ class GitParser(Parser):
                     self.branches.insert(0, self.branch)
             else:
                 self.branch.set_tail(git_commit)
-            
+
             if parents and len(parents) > 1 and not Config().analyze_merges:
                 #Skip merge commits
                 self.commit = None
-            
+
             return
         elif self.commit is None:
             return
-        
+
         # Committer
         match = self.patterns['committer'].match(line)
         if match:
@@ -301,7 +301,7 @@ class GitParser(Parser):
 
             self.commit.actions.append(action)
             self.handler.file(action.f1)
-        
+
             return
 
         # File moved/copied

--- a/pycvsanaly2/extensions/Hunks.py
+++ b/pycvsanaly2/extensions/Hunks.py
@@ -235,6 +235,26 @@ class Hunks(Extension):
         profiler_stop("get_commit_data")
         return hunks
 
+    def get_patches(self, repo, repo_uri, repo_id, db, cursor):
+        profiler_start("Hunks: fetch all patches")
+        icursor = ICursor(cursor, self.INTERVAL_SIZE)
+        # Get the patches from this repository
+        query = """select p.commit_id, p.patch, s.rev
+                    from patches p, scmlog s
+                    where p.commit_id = s.id and
+                    s.repository_id = ? and
+                    p.patch is not NULL"""
+        icursor.execute(statement(query, db.place_holder), (repo_id,))
+        profiler_stop("Hunks: fetch all patches", delete=True)
+
+        rs = icursor.fetchmany()
+
+        while rs:
+          for commit_id, patch_content, rev in rs:
+            yield (commit_id, patch_content, rev)
+
+          rs = icursor.fetchmany()
+
     def run(self, repo, uri, db):
         # Start the profiler, per every other extension
         profiler_start("Running hunks extension")
@@ -266,59 +286,48 @@ class Hunks(Extension):
                     "Error creating repository %s. Exception: %s" % \
                     (repo.get_uri(), str(e)))
 
-        profiler_start("Hunks: fetch all patches")
-        icursor = ICursor(read_cursor, self.INTERVAL_SIZE)
-        # Get the patches from this repository
-        query = """select p.commit_id, p.patch, s.rev
-                    from patches p, scmlog s
-                    where p.commit_id = s.id and
-                    s.repository_id = ? and
-                    p.patch is not NULL"""
-        icursor.execute(statement(query, db.place_holder), (repo_id,))
-        profiler_stop("Hunks: fetch all patches", delete=True)
-
         self.__prepare_table(connection)
         fp = FilePaths(db)
-        rs = icursor.fetchmany()
 
-        while rs:
-            for commit_id, patch_content, rev in rs:
-                for hunk in self.get_commit_data(patch_content):
-                    # Get the file ID from the database for linking
-                    hunk_file_name = re.sub(r'^[ab]\/', '',
-                                            hunk.file_name.strip())
-                    file_id = fp.get_file_id(hunk_file_name, commit_id)
+        patches = self.get_patches(repo, path or repo.get_uri(), repo_id, db,
+                                   read_cursor)
 
-                    if file_id == None:
-                        printdbg("file not found")
-                        if repo.type == "git":
-                            # The liklihood is that this is a merge, not a
-                            # missing ID from some data screwup.
-                            # We'll just continue and throw this away
-                            continue
-                        else:
-                            printerr("No file ID found for hunk " + \
-                                     hunk_file_name + \
-                                     " at commit " + str(commit_id))
+        for commit_id, patch_content, rev in patches:
+            for hunk in self.get_commit_data(patch_content):
+                # Get the file ID from the database for linking
+                hunk_file_name = re.sub(r'^[ab]\/', '',
+                                        hunk.file_name.strip())
+                file_id = fp.get_file_id(hunk_file_name, commit_id)
 
-                    insert = """insert into hunks(file_id, commit_id,
-                                old_start_line, old_end_line, new_start_line,
-                                new_end_line)
-                                values(?,?,?,?,?,?)"""
+                if file_id == None:
+                    printdbg("file not found")
+                    if repo.type == "git":
+                        # The liklihood is that this is a merge, not a
+                        # missing ID from some data screwup.
+                        # We'll just continue and throw this away
+                        continue
+                    else:
+                        printerr("No file ID found for hunk " + \
+                                 hunk_file_name + \
+                                 " at commit " + str(commit_id))
 
-                    execute_statement(statement(insert, db.place_holder),
-                                      (file_id, commit_id,
-                                       hunk.old_start_line,
-                                       hunk.old_end_line,
-                                       hunk.new_start_line,
-                                       hunk.new_end_line),
-                                       write_cursor,
-                                       db,
-                                       "Couldn't insert hunk, dup record?",
-                                       exception=ExtensionRunError)
+                insert = """insert into hunks(file_id, commit_id,
+                            old_start_line, old_end_line, new_start_line,
+                            new_end_line)
+                            values(?,?,?,?,?,?)"""
+
+                execute_statement(statement(insert, db.place_holder),
+                                  (file_id, commit_id,
+                                   hunk.old_start_line,
+                                   hunk.old_end_line,
+                                   hunk.new_start_line,
+                                   hunk.new_end_line),
+                                   write_cursor,
+                                   db,
+                                   "Couldn't insert hunk, dup record?",
+                                   exception=ExtensionRunError)
 
             connection.commit()
-            rs = icursor.fetchmany()
 
         read_cursor.close()
         connection.commit()

--- a/pycvsanaly2/extensions/Patches.py
+++ b/pycvsanaly2/extensions/Patches.py
@@ -19,11 +19,11 @@
 
 from repositoryhandler.backends.watchers import DIFF
 from repositoryhandler.Command import CommandError, CommandRunningError
-from pycvsanaly2.Database import (SqliteDatabase, MysqlDatabase, 
+from pycvsanaly2.Database import (SqliteDatabase, MysqlDatabase,
         TableAlreadyExists, statement, ICursor, execute_statement)
 from pycvsanaly2.profile import profiler_start, profiler_stop
 from pycvsanaly2.Config import Config
-from pycvsanaly2.extensions import (Extension, register_extension, 
+from pycvsanaly2.extensions import (Extension, register_extension,
     ExtensionRunError)
 from pycvsanaly2.utils import to_utf8, printerr, printdbg, uri_to_filename
 from io import BytesIO
@@ -42,11 +42,11 @@ class PatchJob(Job):
 
         io = BytesIO()
         wid = self.repo.add_watch(DIFF, diff_line, io)
-        
+
         done = False
         failed = False
         retries = 3
-        
+
         while not done and not failed:
             try:
                 self.repo.show(self.repo_uri, self.rev)
@@ -54,18 +54,18 @@ class PatchJob(Job):
                 done = True
             except (CommandError, CommandRunningError) as e:
                 if retries > 0:
-                    printerr("Error running show command: %s, trying again", 
+                    printerr("Error running show command: %s, trying again",
                              (str(e),))
                     retries -= 1
                     io.seek(0)
                 elif retries <= 0:
                     failed = True
-                    printerr("Error running show command: %s, FAILED", 
+                    printerr("Error running show command: %s, FAILED",
                              (str(e),))
                     self.data = None
-    
+
         self.repo.remove_watch(DIFF, wid)
-        
+
         return self.data
 
     def run(self, repo, repo_uri):
@@ -94,7 +94,7 @@ class DBPatch(object):
 
     def __str__(self):
         return "<Patch ID: %s, commit_id: %s, data: %s>" % \
-                (str(self.id), str(self.commit_id), 
+                (str(self.id), str(self.commit_id),
                  to_utf8(self.patch).decode("utf-8"))
 
 
@@ -130,7 +130,7 @@ class Patches(Extension):
                                 id INT primary key,
                                 commit_id integer,
                                 patch LONGTEXT
-                                -- FOREIGN KEY (commit_id) 
+                                -- FOREIGN KEY (commit_id)
                                 --    REFERENCES scmlog(id)
                                 ) ENGINE=InnoDB, CHARACTER SET=utf8""")
             except MySQLdb.OperationalError, e:
@@ -145,7 +145,7 @@ class Patches(Extension):
         cursor.close()
 
     def __get_patches_for_repository(self, repo_id, cursor):
-        query = """SELECT p.commit_id from patches p, scmlog s 
+        query = """SELECT p.commit_id from patches p, scmlog s
                 WHERE p.commit_id = s.id and repository_id = ?"""
         cursor.execute(statement(query, self.db.place_holder), (repo_id,))
         commits = [res[0] for res in cursor.fetchall()]
@@ -155,21 +155,21 @@ class Patches(Extension):
     def __process_finished_jobs(self, job_pool, write_cursor, db):
         finished_job = job_pool.get_next_done(0)
 
-        # scmlog_id is the commit ID. For some reason, the 
+        # scmlog_id is the commit ID. For some reason, the
         # documentation advocates tablename_id as the reference,
         # but in the source, these are referred to as commit IDs.
         # Don't ask me why!
         while finished_job is not None:
             p = DBPatch(None, finished_job.commit_id, finished_job.data)
 
-            execute_statement(statement(DBPatch.__insert__, 
+            execute_statement(statement(DBPatch.__insert__,
                                         self.db.place_holder),
                               (p.id, p.commit_id, p.patch),
                               write_cursor,
                               db,
                               "Couldn't insert, duplicate patch?",
                               exception=ExtensionRunError)
-            
+
             finished_job = job_pool.get_next_done(0)
 
     def run(self, repo, uri, db):
@@ -189,7 +189,7 @@ class Patches(Extension):
         cnn = self.db.connect()
 
         cursor = cnn.cursor()
-        cursor.execute(statement("SELECT id from repositories where uri = ?", 
+        cursor.execute(statement("SELECT id from repositories where uri = ?",
                                  db.place_holder), (repo_uri,))
         repo_id = cursor.fetchone()[0]
 
@@ -202,7 +202,7 @@ class Patches(Extension):
             self.__create_table(cnn)
         except TableAlreadyExists:
             printdbg("Patches table exists already, getting max ID")
-            cursor.execute(statement("SELECT max(id) from patches", 
+            cursor.execute(statement("SELECT max(id) from patches",
                                      db.place_holder))
             id = cursor.fetchone()[0]
             if id is not None:
@@ -213,7 +213,7 @@ class Patches(Extension):
             raise ExtensionRunError(str(e))
 
         queuesize = Config().max_threads
-        job_pool = JobPool(repo, path or repo.get_uri(), queuesize=queuesize)        
+        job_pool = JobPool(repo, path or repo.get_uri(), queuesize=queuesize)
         i = 0
 
         write_cursor = cnn.cursor()
@@ -222,10 +222,10 @@ class Patches(Extension):
                                   "from scmlog where repository_id = ?",
                                     db.place_holder), (repo_id,))
         rs = icursor.fetchmany()
-        
+
         while rs:
             for commit_id, revision, composed_rev in rs:
-                if commit_id in commits: 
+                if commit_id in commits:
                     continue
 
                 if composed_rev:
@@ -254,12 +254,12 @@ class Patches(Extension):
         cursor.close()
         cnn.close()
         profiler_stop("Running Patches extension", delete=True)
-        
+
     def backout(self, repo, uri, db):
         update_statement = """delete from patches
                               where commit_id in (select s.id from scmlog s
                                           where s.repository_id = ?)"""
 
         self._do_backout(repo, uri, db, update_statement)
-        
+
 register_extension("Patches", Patches)

--- a/pycvsanaly2/extensions/PatchesAndHunks.py
+++ b/pycvsanaly2/extensions/PatchesAndHunks.py
@@ -1,0 +1,70 @@
+# Copyright (C) 2009 LibreSoft
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+#
+# Authors :
+#       Carlos Garcia Campos <carlosgc@gsyc.escet.urjc.es>
+
+from repositoryhandler.backends.watchers import DIFF
+from repositoryhandler.Command import CommandError, CommandRunningError
+from pycvsanaly2.Database import (SqliteDatabase, MysqlDatabase,
+        TableAlreadyExists, statement, ICursor, execute_statement)
+from pycvsanaly2.profile import profiler_start, profiler_stop
+from pycvsanaly2.Config import Config
+from pycvsanaly2.extensions import (Extension, register_extension,
+    ExtensionRunError)
+from pycvsanaly2.extensions.Hunks import Hunks
+from pycvsanaly2.extensions.Patches import PatchJob
+from pycvsanaly2.utils import to_utf8, printerr, printdbg, uri_to_filename
+from io import BytesIO
+from Jobs import JobPool, Job
+
+class PatchesAndHunks(Extension):
+    """An extension to insert hunks without the intermediate patches step."""
+    INTERVAL_SIZE = 100
+
+    def __init__(self):
+        self.db = None
+
+    def run(self, repo, uri, db):
+        def patch_generator(repo, repo_uri, repo_id, db, cursor):
+            icursor = ICursor(cursor, self.INTERVAL_SIZE)
+            icursor.execute(statement("SELECT id, rev, composed_rev " + \
+                                      "from scmlog where repository_id = ?",
+                                      db.place_holder), (repo_id,))
+
+            rs = icursor.fetchmany()
+
+            while rs:
+                for commit_id, revision, composed_rev in rs:
+                    # Get the patch
+                    pj = PatchJob(revision, commit_id)
+
+                    path = uri_to_filename(repo_uri)
+                    pj.run(repo, path or repo.get_uri())
+
+                    # Yield the patch to hunks
+                    yield (pj.commit_id, pj.data, pj.rev)
+
+                rs = icursor.fetchmany()
+
+
+        profiler_start("Running PatchesAndHunks extension")
+
+        hunks = Hunks()
+        hunks.get_patches = patch_generator
+        hunks.run(repo, uri, db)
+
+register_extension("PatchesAndHunks", PatchesAndHunks)


### PR DESCRIPTION
This pull request adds a PatchesAndHunks extension, which is just patches and hunks joined together.

This is a feature request from our deployment venue, as patch data isn't really needed in the DB, it's just how we separated the concerns.

PatchesAndHunks isn't threaded, but with Git it seems to run at about the same speed as running Patches/Hunks individually. I'm not interested in threading this code.

There's a change to Hunks so it uses a generator. I'm not sure that this slows the code any, but we'll look at the Jenkins results to see if it slows.

I'm also attaching a commit in here that fixes the doctests for dates, which were not updated when we changed to using commit-date, author-date.
