### PR TITLE
[CommitsLOC] Removed "origin" and set default to (0,0) (e.g. if merge commit).

### DIFF
--- a/pycvsanaly2/extensions/CommitsLOC.py
+++ b/pycvsanaly2/extensions/CommitsLOC.py
@@ -164,7 +164,7 @@ class GitLineCounter(LineCounter):
         self.lines = {}
         
         cmd = [self.git, 'log', '--all', '--topo-order', '--shortstat', 
-               '--pretty=oneline', 'origin']
+               '--pretty=oneline']
         c = Command(cmd, uri)
         try:
             c.run(parser_out_func=self.__parse_line)
@@ -189,6 +189,7 @@ class GitLineCounter(LineCounter):
             # we only have two kind of lines,
             # if it's not a diffstat, it's a rev line
             self.rev = line.split(None, 1)[0]
+            self.lines[self.rev] = (0, 0)
     
     def get_lines_for_revision(self, revision):
         return self.lines.get(revision, (0, 0))


### PR DESCRIPTION
Extension "CommitsLOC" forced git to use the origin. This crashed when no origin is given. So i removed the "origin".

I also set the default to (0,0). Just in case a commit is empty (e.g. merge commit).
