### PR TITLE
[FilePaths] Save every file_path for a real file (no folders). Skip only 

### DIFF
--- a/pycvsanaly2/DBContentHandler.py
+++ b/pycvsanaly2/DBContentHandler.py
@@ -419,10 +419,6 @@ class DBContentHandler(ContentHandler):
                 parent_id = parent
                 parent = node_id
 
-                # Also add to file_paths
-                self.__add_file_path(commit_id, node_id,
-                    re.sub('^\d+://', '', rpath))
-
                 self.file_cache[rpath] = (node_id, parent_id)
 
             assert node_id is not None
@@ -475,9 +471,6 @@ class DBContentHandler(ContentHandler):
 
         file_id = self.__add_new_file_and_link(file_name, parent_id, log.id)
         self.file_cache[path] = (file_id, parent_id)
-
-        # Save also file_path
-        self.__add_file_path(log.id, file_id, path)
 
         return file_id
 
@@ -538,9 +531,6 @@ class DBContentHandler(ContentHandler):
         dbfilecopy.new_file_name = new_file_name
         self.__add_new_copy(dbfilecopy)
 
-        # Save also file_path
-        self.__add_file_path(log.id, file_id, path)
-
         return file_id
 
     def __action_copy(self, path, prefix, log, action, dbaction):
@@ -585,9 +575,6 @@ class DBContentHandler(ContentHandler):
         dbfilecopy.action_id = dbaction.id
         dbfilecopy.from_commit = from_commit_id
         self.__add_new_copy(dbfilecopy)
-
-        # Save also file_path
-        self.__add_file_path(log.id, file_id, path)
 
         return file_id
 
@@ -647,9 +634,6 @@ class DBContentHandler(ContentHandler):
         dbfilecopy.action_id = dbaction.id
         dbfilecopy.from_commit = from_commit_id
         self.__add_new_copy(dbfilecopy)
-
-        # Save also file_path
-        self.__add_file_path(log.id, file_id, path)
 
         return file_id
 
@@ -713,6 +697,10 @@ class DBContentHandler(ContentHandler):
                     continue
             else:
                 assert "Unknown action type %s" % (action.type)
+
+            # For every action the full file_path should be saved (except when file delete).
+            if action.type != 'D':
+                self.__add_file_path(log.id, file_id, path)
 
             dbaction.file_id = file_id
             self.actions.append(dbaction)


### PR DESCRIPTION
As discussed before (see Issues #96 and #105) file_paths did not always worked as expected. Having a closer look it also added folders to file_paths.

So I changed the behavior for file_paths. Now every file of a commit that is not delete (and only files, no folders) will be written with the full path to file_paths. I also did some refactorings.

Questions for discussion:
1.) Should deleted files also be listed in file_paths?
2.) Should folders also be listed in file_paths?
3.) Should file_paths be merged with the table actions? It's essentially the same thing, only that deleted files are currently not listed. Table actions could get another field "file_path" with the current path of that file.

I would be willing to refactor CVSAnalY in that way, that table file_paths will be dropped and table actions will be extended. I would also refactor all code, that is currently using file_paths.

What are you thinking of this?
