### PR TITLE
[Refactoring] Merge table actions and file_paths.

### DIFF
--- a/docs/cvsanaly.mdown
+++ b/docs/cvsanaly.mdown
@@ -203,6 +203,7 @@ The `actions` table describes the different actions performed in every commit. I
 * `commit_id`: The identifier of the commit where the action was
 performed. This is a foreign key that references the `id` field of the `scmlog` table.
 * `branch_id`: The identifier of the branch where the action was performed. This is a foreign key that references the `id` field of the `branches` table. 
+* `current_file_path`: The current path of the file
 
 **Note:** Not all of the action types are always supported, for example, CVS repositories only support the `A`, `M` and `D` actions.
 
@@ -234,15 +235,6 @@ The `file_copies` table is used to store additional information about actions th
 * `from_commit_id`: identifier of the commit from which the operation is carried out. The source file contents are taken from the revision associated to this commit identifier. This is a foreign key that references the `id` field of the `scmlog` table
 * `new_file_name`: contains the new name of the file for rename actions or `NULL` for other actions. 
 * `action_id`: the identifier of the action. This is a foreign key that references the `id` field of the `actions` table.
-
-#### file_paths table
-
-The `file_paths` table is used to either look up the `file_id` for a given `file_path` and `commit_id` or to look up the current `file_path` for a given `file_id` and `commit_id`. This is an alternative table to files, `file_links` and `actions`.
-
-* `id`: Database identifier.
-* `commit_id`: The identifier of the commit where the file was introduced or renamed. This is a foreign key that references the `id` field of the `scmlog` table.
-* `file_id`: The identifier of the file. This is a foreign key that references the `id` field of the `files` table.
-* `file_path`: The full path for the `file_id` at the given `commit_id`
 
 #### branches table
 

--- a/pycvsanaly2/extensions/FilePaths.py
+++ b/pycvsanaly2/extensions/FilePaths.py
@@ -162,7 +162,7 @@ class FilePaths(object):
         cnn = db.connect()
         
         cursor = cnn.cursor()
-        query = """SELECT file_path from file_paths
+        query = """SELECT current_file_path from actions
                    WHERE file_id=? AND commit_id <= ?
                    ORDER BY commit_id DESC LIMIT 1"""
         cursor.execute(statement(query, db.place_holder), (file_id, commit_id))
@@ -224,8 +224,8 @@ class FilePaths(object):
         db = self.__dict__['db']
         cnn = db.connect()
         cursor = cnn.cursor()
-        query = """SELECT file_id from file_paths
-                   WHERE file_path = ? AND commit_id <= ?
+        query = """SELECT file_id from actions
+                   WHERE current_file_path = ? AND commit_id <= ?
                    ORDER BY commit_id DESC LIMIT 1"""
         cursor.execute(statement(query, db.place_holder),
                         (file_path, commit_id))


### PR DESCRIPTION
For this I deleted table file_paths and all functions for it. I also added the field 'current_file_path' to the table actions. All methods, that used file_paths are refactored to now use the actions table.

I made a testrun with Hunks and HunkBlames. Both still worked a intended. In my tests the table actions grew from ~ 330 kb to ~ 1 mb. For the extra information and improved speed I think, this is reasonable.

This is the 'answer' to Issue #108.

Feedback is welcomed.
