### PR TITLE
Better Merge parsing

### DIFF
--- a/pycvsanaly2/DBContentHandler.py
+++ b/pycvsanaly2/DBContentHandler.py
@@ -663,7 +663,7 @@ class DBContentHandler(ContentHandler):
             if action.type == 'A':
                 # A file has been added
                 file_id = self.__action_add(path, prefix, log)
-            elif action.type == 'M':
+            elif action.type == 'M' or action.type == 'T':
                 # A file has been modified
                 file_id = self.__get_file_for_path(path, log.id)[0]
             elif action.type == 'D':

--- a/pycvsanaly2/GitParser.py
+++ b/pycvsanaly2/GitParser.py
@@ -93,7 +93,7 @@ class GitParser(Parser):
                                   " \d{4}) ([+-]\d{4})$")
     patterns['author-date'] = re.compile("^AuthorDate: (.* \d+ \d+:\d+:\d+" + \
                                   " \d{4}) ([+-]\d{4})$")
-    patterns['file'] = re.compile("^[ACDMRTUXB]{0,1}([MAD])[ \t]+(.*)$")
+    patterns['file'] = re.compile("^[ACDMRTUXB]{0,1}([MADT])[ \t]+(.*)$")
     patterns['file-moved'] = re.compile("^[ACDMRTUXB]{0,1}([RC])[0-9]+[ \t]+(.*)[ \t]+(.*)$")
     patterns['branch'] = re.compile("refs/remotes/([^,]*)/([^,]*)")
     patterns['local-branch'] = re.compile("refs/heads/([^,]*)")

--- a/pycvsanaly2/GitParser.py
+++ b/pycvsanaly2/GitParser.py
@@ -93,8 +93,8 @@ class GitParser(Parser):
                                   " \d{4}) ([+-]\d{4})$")
     patterns['author-date'] = re.compile("^AuthorDate: (.* \d+ \d+:\d+:\d+" + \
                                   " \d{4}) ([+-]\d{4})$")
-    patterns['file'] = re.compile("^([MAD])[ \t]+(.*)$")
-    patterns['file-moved'] = re.compile("^([RC])[0-9]+[ \t]+(.*)[ \t]+(.*)$")
+    patterns['file'] = re.compile("^[ACDMRTUXB]{0,1}([MAD])[ \t]+(.*)$")
+    patterns['file-moved'] = re.compile("^[ACDMRTUXB]{0,1}([RC])[0-9]+[ \t]+(.*)[ \t]+(.*)$")
     patterns['branch'] = re.compile("refs/remotes/([^,]*)/([^,]*)")
     patterns['local-branch'] = re.compile("refs/heads/([^,]*)")
     patterns['tag'] = re.compile("tag: refs/tags/([^,]*)")

--- a/pycvsanaly2/PatchParser.py
+++ b/pycvsanaly2/PatchParser.py
@@ -15,6 +15,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 import re
+from pycvsanaly2.utils import printerr
 
 
 binary_files_re = 'Binary files (.*) and (.*) differ\n'
@@ -410,7 +411,13 @@ def iter_file_patch(iter_lines, allow_dirty=False):
                 yield saved_lines
             saved_lines = []
         elif line.startswith('@@'):
-            hunk = hunk_from_header(line)
+            try:
+                hunk = hunk_from_header(line)
+            except MalformedHunkHeader, e:
+                if allow_dirty:
+                    printerr("Error: MalformedHunkHeader; Probably merge commit. Skipping.")
+                    continue
+                raise e
             orig_range = hunk.orig_range
         saved_lines.append(line)
     if len(saved_lines) > 0:


### PR DESCRIPTION
Added handling of two-way merges into CVSAnalY. Also added "Type Change", so file's that are change e.g. to a sym-link are also tracked now (marking them as modified).

Also catching a MalformedHunkHeader to prevent Hunks from failing, when a strange Diff-File shows up (a merge, where files are moved and changed in that merge).

https://github.com/SoftwareIntrospectionLab/repositoryhandler/pull/9 is needed for this.
