### PR TITLE
Extension "CommitsLOC" now dismissing file renames

### DIFF
--- a/pycvsanaly2/extensions/CommitsLOC.py
+++ b/pycvsanaly2/extensions/CommitsLOC.py
@@ -163,8 +163,8 @@ class GitLineCounter(LineCounter):
 
         self.lines = {}
         
-        cmd = [self.git, 'log', '--all', '--topo-order', '--shortstat', 
-               '--pretty=oneline']
+        cmd = [self.git, 'log', '--all', '--topo-order', '--shortstat',
+               '--pretty=oneline', '--find-renames']
         c = Command(cmd, uri)
         try:
             c.run(parser_out_func=self.__parse_line)

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     packages=['pycvsanaly2', 'pycvsanaly2.extensions'],
     long_description=read('README.mdown'),
     scripts = ["cvsanaly2"],
-    install_requires=['repositoryhandler>=0.3.5', 'guilty>=2.0'],
+    install_requires=['repositoryhandler>=0.3.6', 'guilty>=2.0'],
     dependency_links = ['https://github.com/SoftwareIntrospectionLab/repositoryhandler/tarball/master#egg=repositoryhandler-0.3.4',
     'https://github.com/SoftwareIntrospectionLab/guilty/tarball/master#egg=guilty-2.0'],
     classifiers = [


### PR DESCRIPTION
This is to be more in line with https://github.com/SoftwareIntrospectionLab/repositoryhandler/pull/10 and #121.

Also changed versionnumber of repository handler, because it changed a little bit.
