### PR TITLE
Error messages of Content and HunkBlame

### DIFF
--- a/pycvsanaly2/extensions/Content.py
+++ b/pycvsanaly2/extensions/Content.py
@@ -373,6 +373,8 @@ class Content(Extension):
         i = 0
         # Loop through each file and its revision
         for revision, commit_id, file_id, action_type, composed in fr:
+            if action_type == 'D':
+                continue
 #            loop_start = datetime.now()
             if file_id not in code_files:
                 continue

--- a/pycvsanaly2/extensions/Content.py
+++ b/pycvsanaly2/extensions/Content.py
@@ -115,18 +115,17 @@ class ContentJob(Job):
                 printerr("Error obtaining %s@%s. Exception: %s", \
                         (self.path, self.rev, str(e)))
         self.repo.remove_watch(watcher, wid)
-
-        if failed:
-            printerr("Failure due to error")
-        else:
+        
+        results = None
+        if not failed:
             try:
                 results = io.getvalue()
-                return results
             except Exception, e:
                 printerr("Error getting contents." +
                             "Exception: %s", (str(e),))
             finally:
                 io.close()
+        return results
                 
     def _get_file_contents(self):
             """Returns contents of the file, stripped of whitespace 

--- a/pycvsanaly2/extensions/HunkBlame.py
+++ b/pycvsanaly2/extensions/HunkBlame.py
@@ -408,7 +408,7 @@ class HunkBlame(Blame):
                                                         pre_commit_id)
                 if relative_path is None:
                     raise NotValidHunkWarning("Couldn't find path for " + \
-                                              "file ID %d" % file_id)
+                                              "file ID %d at %s" % (file_id, pre_rev))
                 printdbg("Path for %d at %s -> %s", (file_id, pre_rev,
                                                      relative_path))
 


### PR DESCRIPTION
-Ignore action type 'D' when fetching file content, so as to eliminate unnecessary error messages in Content.
-Some minor error message changes in Content and HunkBlame
