### PR TITLE
HunkBlame: Bugfix for most "file path not found"

### DIFF
--- a/pycvsanaly2/extensions/FilePaths.py
+++ b/pycvsanaly2/extensions/FilePaths.py
@@ -225,7 +225,7 @@ class FilePaths(object):
         cnn = db.connect()
         cursor = cnn.cursor()
         query = """SELECT file_id from actions
-                   WHERE current_file_path = ? AND commit_id <= ?
+                   WHERE current_file_path = ? AND commit_id = ?
                    ORDER BY commit_id DESC LIMIT 1"""
         cursor.execute(statement(query, db.place_holder),
                         (file_path, commit_id))

--- a/pycvsanaly2/extensions/HunkBlame.py
+++ b/pycvsanaly2/extensions/HunkBlame.py
@@ -407,8 +407,16 @@ class HunkBlame(Blame):
                 relative_path = self.fp.get_path_from_database(file_id,
                                                         pre_commit_id)
                 if relative_path is None:
-                    raise NotValidHunkWarning("Couldn't find path for " + \
-                                              "file ID %d at %s" % (file_id, pre_rev))
+                    # Maybe the file_id did change (especially when working with different branches).
+                    # Check if a file with the exact same path exists at pre_commit_id
+                    old_file_name = self.fp.get_path_from_database(file_id, commit_id)
+                    new_file_id = self.fp.get_file_id(old_file_name, commit_id)
+                    if new_file_id is None:
+                        raise NotValidHunkWarning("Couldn't find path for " + \
+                                                  "file ID %d at %s" % (file_id, pre_rev))
+                    else:
+                        relative_path = old_file_name
+                
                 printdbg("Path for %d at %s -> %s", (file_id, pre_rev,
                                                      relative_path))
 

--- a/pycvsanaly2/extensions/HunkBlame.py
+++ b/pycvsanaly2/extensions/HunkBlame.py
@@ -409,13 +409,13 @@ class HunkBlame(Blame):
                 if relative_path is None:
                     # Maybe the file_id did change (especially when working with different branches).
                     # Check if a file with the exact same path exists at pre_commit_id
-                    old_file_name = self.fp.get_path_from_database(file_id, commit_id)
-                    new_file_id = self.fp.get_file_id(old_file_name, commit_id)
-                    if new_file_id is None:
+                    current_path = self.fp.get_path_from_database(file_id, commit_id)
+                    pre_file_id = self.fp.get_file_id(current_path, commit_id)
+                    if pre_file_id is None:
                         raise NotValidHunkWarning("Couldn't find path for " + \
                                                   "file ID %d at %s" % (file_id, pre_rev))
                     else:
-                        relative_path = old_file_name
+                        relative_path = current_path
                 
                 printdbg("Path for %d at %s -> %s", (file_id, pre_rev,
                                                      relative_path))


### PR DESCRIPTION
## The issue

I observed, that ´HunkBlame´ had sometimes a hard time to find the file path for the previous commit. This resulted in in the error message:

```
Not a valid hunk: Couldn't find path for file ID 1234 at 15d7f32c76198d342f048af42dabb7893cdb0cae
```
## Debugging

I had a closer look at the issue. ´CVSAnalY´ sometimes assigns a new file_id to the same file, if it occurs on two different branches. Say there is a file "folder/file_name.txt", that is created upstream. ´CVSAnalY´ will correctly marked this as added and assignes a new file_id to it. Than later on there are some branches that work in parallel and that modify "folder/file_name.txt". ´CVSAnalY´ marks this as modifies, but sometimes is creates a new file_id to it.

So later on, when hunk blame wants to find the origin commit, it tries that new file id at the old revision. 

**To be clear**: file_id assignment in `CVSAnalY` is not always consistent. The same file could show up with different ´file_id´s! I haven't had the time to debug the root issue, but it seems to be interconnected with branches.
## Workaround

When no file path with the new file_id could be found at the previous revision, HunkBlame now checks, if the file_path of the current file and revision is present at the previous revision and uses this path. This could still fail, if the file is renamed in between, but chances are good, that the file path is the same. If the file is not present and exception is thrown.

In my test with a closed repository I managed to cut down the number of "Couldn't find path for file ID" from 1547 file id's to zero.
## Refactoring

While fixing this I also change FilePaths `get_file_id` slightly to refactor `Patches`
