### PR TITLE
Non-ascii support 2

### DIFF
--- a/pycvsanaly2/PatchParser.py
+++ b/pycvsanaly2/PatchParser.py
@@ -139,7 +139,7 @@ def hunk_from_header(line):
 
 class HunkLine(object):
     def __init__(self, contents):
-        self.contents = str(contents.encode('utf-8'))
+        self.contents = contents
 
     def get_str(self, leadchar):
         if self.contents == "\n" and leadchar == " " and False:
@@ -202,7 +202,7 @@ class Hunk(object):
         if self.tail is None:
             tail_str = ''
         else:
-            tail_str = ' ' + str(self.tail.encode('utf-8'))
+            tail_str = ' ' + self.tail
         return "@@ -%s +%s @@%s\n" % (self.range_str(self.orig_pos,
                                                      self.orig_range),
                                       self.range_str(self.mod_pos,

--- a/pycvsanaly2/extensions/Hunks.py
+++ b/pycvsanaly2/extensions/Hunks.py
@@ -255,7 +255,6 @@ class Hunks(Extension):
 
         while rs:
             for commit_id, file_id, patch_content, rev in rs:
-                patch_content = unicode(to_utf8(patch_content), "utf-8").encode('ascii', 'ignore') #Make shure, that all wrong characters are ignored
                 yield (commit_id, file_id, patch_content, rev)
             
             rs = icursor.fetchmany()

--- a/pycvsanaly2/extensions/Hunks.py
+++ b/pycvsanaly2/extensions/Hunks.py
@@ -255,7 +255,7 @@ class Hunks(Extension):
 
         while rs:
             for commit_id, file_id, patch_content, rev in rs:
-                yield (commit_id, file_id, patch_content, rev)
+                yield (commit_id, file_id, to_utf8(patch_content), rev)
             
             rs = icursor.fetchmany()
 

--- a/pycvsanaly2/extensions/PatchLOC.py
+++ b/pycvsanaly2/extensions/PatchLOC.py
@@ -95,7 +95,7 @@ class PatchLOC(Extension):
         rs = icursor.fetchmany()
         while rs:
             for commit_id, file_id, patch_content, rev in rs:
-                yield (commit_id, file_id, unicode(to_utf8(patch_content), "utf-8"), rev)
+                yield (commit_id, file_id, to_utf8(patch_content), rev)
             rs = icursor.fetchmany()
 
     def count_lines(self, patch_content):

--- a/pycvsanaly2/extensions/Patches.py
+++ b/pycvsanaly2/extensions/Patches.py
@@ -53,7 +53,7 @@ class PatchJob(Job):
         while not done and not failed:
             try:
                 self.repo.show(self.repo_uri, self.rev)
-                self.data = unicode(to_utf8(io.getvalue().strip()), "utf-8").encode('ascii', 'ignore') #Make shure, that all wrong characters are ignored
+                self.data = io.getvalue().strip()
                 done = True
             except (CommandError, CommandRunningError) as e:
                 if retries > 0:

--- a/pycvsanaly2/extensions/Patches.py
+++ b/pycvsanaly2/extensions/Patches.py
@@ -53,7 +53,7 @@ class PatchJob(Job):
         while not done and not failed:
             try:
                 self.repo.show(self.repo_uri, self.rev)
-                self.data = io.getvalue().strip()
+                self.data = to_utf8(unicode(to_utf8(io.getvalue()), "utf-8", errors='replace')).strip()
                 done = True
             except (CommandError, CommandRunningError) as e:
                 if retries > 0:

--- a/pycvsanaly2/extensions/PatchesAndHunks.py
+++ b/pycvsanaly2/extensions/PatchesAndHunks.py
@@ -27,7 +27,7 @@ from pycvsanaly2.extensions import (Extension, register_extension,
     ExtensionRunError)
 from pycvsanaly2.extensions.Hunks import Hunks
 from pycvsanaly2.extensions.Patches import PatchJob, DBPatch
-from pycvsanaly2.utils import to_utf8, printerr, printdbg, uri_to_filename
+from pycvsanaly2.utils import printerr, printdbg, uri_to_filename
 from io import BytesIO
 from Jobs import JobPool, Job
 
@@ -58,7 +58,7 @@ class PatchesAndHunks(Extension):
                     p = DBPatch(db, commit_id, pj.data)
                     # Yield the patch to hunks
                     for file_id, patch in p.file_patches():
-                        yield (pj.commit_id, file_id, str(patch), pj.rev)
+                        yield (pj.commit_id, file_id, patch, pj.rev)
 
                 rs = icursor.fetchmany()
 

--- a/pycvsanaly2/extensions/PatchesAndHunks.py
+++ b/pycvsanaly2/extensions/PatchesAndHunks.py
@@ -58,8 +58,7 @@ class PatchesAndHunks(Extension):
                     p = DBPatch(db, commit_id, pj.data)
                     # Yield the patch to hunks
                     for file_id, patch in p.file_patches():
-                        patch = unicode(to_utf8(patch), "utf-8").encode('ascii', 'ignore') #Make shure, that all wrong characters are ignored
-                        yield (pj.commit_id, file_id, patch, pj.rev)
+                        yield (pj.commit_id, file_id, str(patch), pj.rev)
 
                 rs = icursor.fetchmany()
 


### PR DESCRIPTION
This should support unicode characters and replace all invalide charaters, so that patches are stored correctly.

This needs to be done, because in git also non unicode string could be stored, and we want to make sure, that we have them all covert.

With this, the conversion is taking place, when read from git in Patches. Hunks and PatchLOC can then access that from the database and only need to use to_utf8() for making it easier for PatchParser.

This is in response to #131 an build on top of it. See #131 for more discussion.
