### PR TITLE
[FilePaths] Stop ignoring cases, when looking for file_paths

### DIFF
--- a/pycvsanaly2/extensions/FilePaths.py
+++ b/pycvsanaly2/extensions/FilePaths.py
@@ -225,7 +225,7 @@ class FilePaths(object):
         cnn = db.connect()
         cursor = cnn.cursor()
         query = """SELECT file_id from actions
-                   WHERE current_file_path = ? AND commit_id = ?
+                   WHERE binary current_file_path = ? AND commit_id = ?
                    ORDER BY commit_id DESC LIMIT 1"""
         cursor.execute(statement(query, db.place_holder),
                         (file_path, commit_id))


### PR DESCRIPTION
This reduces "Couldn't insert, duplicate patch?".
File names that get change from "UpperCase" to "uppercase" are two different files in git and CVSAnalY. The SQL query now makes sure, that the exact file path matches.

Not sure, if this also works with SQLite.
