### PR TITLE
[Patches + PatchLOC + Hunks] Better new line handling.

### DIFF
--- a/pycvsanaly2/PatchParser.py
+++ b/pycvsanaly2/PatchParser.py
@@ -292,6 +292,11 @@ def iter_hunks(iter_lines, allow_dirty=False):
                     mod_size += 1
             except StopIteration:
                 break
+            except MalformedLine, e:
+                if allow_dirty:
+                    printerr("Error: MalformedLine; Probably binary file. Skipping line.")
+                    continue
+                raise e
     if hunk is not None:
         yield hunk
 

--- a/pycvsanaly2/extensions/Hunks.py
+++ b/pycvsanaly2/extensions/Hunks.py
@@ -147,7 +147,7 @@ class Hunks(Extension):
 
     def get_commit_data(self, patch_content):
         profiler_start("get_commit_data")
-        lines = [l + "\n" for l in patch_content.splitlines() if l]
+        lines = [l + "\n" for l in patch_content.split("\n") if l]
         hunks = []
 
         for patch in [p for p in parse_patches(lines, allow_dirty=True, \

--- a/pycvsanaly2/extensions/PatchLOC.py
+++ b/pycvsanaly2/extensions/PatchLOC.py
@@ -102,7 +102,7 @@ class PatchLOC(Extension):
         added = 0
         removed = 0
 
-        for line in patch_content.splitlines():
+        for line in patch_content.split("\n"):
             if self.patterns['old_file'].match(line) or self.patterns['no_old_file'].match(line):
                 # skip line
                 continue

--- a/pycvsanaly2/extensions/Patches.py
+++ b/pycvsanaly2/extensions/Patches.py
@@ -91,7 +91,7 @@ class DBPatch(object):
         self.fp = FilePaths(self.db)
         
     def file_patches(self):
-        lines = [l+"\n" for l in self.data.splitlines() if l]
+        lines = [l+"\n" for l in self.data.split("\n") if l]
         
         cnn = self.db.connect()
         for f in iter_file_patch(lines, True):


### PR DESCRIPTION
Git can store content, that has other new lines like \r (CR). But git outputs lines, that are separated by a \r not as different lines, only as one line (e.g. "+ first line\rsecondline"). For the patch handling, it's importend, that lines are only splited at "\n", so that no MalformedLine (e.g. without a "+ " or "- " in the beginning) occurs.

Not sure, if this works on Windows, but with unix (linux, mac etc.) this should be fine.

Also added a catch for MalformedLine in PatchParser, to better know, if this occurs.

All in all, this increases the coverage of Patches and with that Hunks.
