### PR TITLE
[HunkBlame] Improved get_previous_commit

### DIFF
--- a/pycvsanaly2/extensions/HunkBlame.py
+++ b/pycvsanaly2/extensions/HunkBlame.py
@@ -291,12 +291,18 @@ class HunkBlame(Blame):
 
         # calculate rev and commit_id of previous commit
         try:
-            pre_rev = repo.get_previous_commit(self.uri, commit_rev, file_name)
+            pre_rev = repo.get_previous_commit(self.uri, commit_rev, file_name, follow=False)
         except NotImplementedError:
             raise NotValidHunkWarning("Repository type not supported!")
             return None, None
         except Exception as e:
             pre_rev = None
+
+        if pre_rev is None:
+            try:
+                pre_rev = repo.get_previous_commit(self.uri, commit_rev, file_name, follow=True)
+            except Exception as e:
+                pre_rev = None
 
         pre_commit_query = """SELECT id FROM scmlog WHERE rev = ?"""
         try:

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     packages=['pycvsanaly2', 'pycvsanaly2.extensions'],
     long_description=read('README.mdown'),
     scripts = ["cvsanaly2"],
-    install_requires=['repositoryhandler>=0.3.6.1', 'guilty>=2.0'],
+    install_requires=['repositoryhandler>=0.3.6.2', 'guilty>=2.0'],
     dependency_links = ['https://github.com/SoftwareIntrospectionLab/repositoryhandler/tarball/master#egg=repositoryhandler-0.3.4',
     'https://github.com/SoftwareIntrospectionLab/guilty/tarball/master#egg=guilty-2.0'],
     classifiers = [


### PR DESCRIPTION
- Check get_previous_commit again with flag "follow" is file could not be found before.
- This needs a newer version of repositoryhandler (see https://github.com/SoftwareIntrospectionLab/repositoryhandler/pull/13 )
