### PR TITLE
[HunkBlame] Refactored the way previous file and revision is detected.

### DIFF
--- a/pycvsanaly2/extensions/HunkBlame.py
+++ b/pycvsanaly2/extensions/HunkBlame.py
@@ -70,8 +70,6 @@ class HunkBlameJob(Job):
     def __do_the_blame(self, repo, repo_uri):
         printdbg("Running HunkBlameJob for %s@%s", (self.prev_path, self.prev_rev))
 
-        success = True
-
         def blame_line(line, p):
             p.feed(line)
 
@@ -115,11 +113,11 @@ class HunkBlameJob(Job):
                        start=start, end=end)
             self.collect_results(out)
         except RepositoryCommandError, e:
-            success = False
+            self.failed = True
         p.end()
         repo.remove_watch(BLAME, wid)
 
-        return success
+        return not self.failed
 
     def run(self, repo, repo_uri):
         try:

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     packages=['pycvsanaly2', 'pycvsanaly2.extensions'],
     long_description=read('README.mdown'),
     scripts = ["cvsanaly2"],
-    install_requires=['repositoryhandler>=0.3.6.2', 'guilty>=2.0'],
+    install_requires=['repositoryhandler>=0.3.6.3', 'guilty>=2.0'],
     dependency_links = ['https://github.com/SoftwareIntrospectionLab/repositoryhandler/tarball/master#egg=repositoryhandler-0.3.4',
     'https://github.com/SoftwareIntrospectionLab/guilty/tarball/master#egg=guilty-2.0'],
     classifiers = [


### PR DESCRIPTION
- Moved calculation of previous file and revision to HunkBlameJob and repositoryhandler
- HunkBlameJob now gets the current rev and file_path and should calculate what the previous rev and path is.
- HunkBlameJob takes care of the calcualtion, because it now tries a second time, if it failed the first time, with the "follow" option on.
- This needs a newer version of repositoryhandler, since a new functionality is used (see SoftwareIntrospectionLab/repositoryhandler#15)

This dramaticaly **decreases** fatal errors such as "no such path path/to/file in 0a4dabf3" or "path/to/file has only 124 lines". All in all this needs about the same time, as the previous implementation.

@linzhp and @Lewisham: Since this is quite a bit refactoring for HunkBlame, please review my changes and let me know how this performs for you.
