### PR TITLE
Ignore whitespaces for Patches, CommitLOC and HunkBlame

### DIFF
--- a/pycvsanaly2/extensions/CommitsLOC.py
+++ b/pycvsanaly2/extensions/CommitsLOC.py
@@ -165,7 +165,7 @@ class GitLineCounter(LineCounter):
         self.lines = {}
         
         cmd = [self.git, 'log', '--all', '--topo-order', '--shortstat',
-               '--pretty=oneline', '--find-copies']
+               '--pretty=oneline', '--find-copies', '--ignore-all-space']
         c = Command(cmd, uri)
         try:
             c.run(parser_out_func=self.__parse_line)

--- a/pycvsanaly2/extensions/HunkBlame.py
+++ b/pycvsanaly2/extensions/HunkBlame.py
@@ -110,7 +110,7 @@ class HunkBlameJob(Job):
         wid = repo.add_watch(BLAME, blame_line, p)
         try:
             repo.blame(os.path.join(repo_uri, self.prev_path), self.prev_rev,
-                       start=start, end=end)
+                       start=start, end=end, ignore_whitespaces=True)
             self.collect_results(out)
         except RepositoryCommandError, e:
             self.failed = True

--- a/pycvsanaly2/extensions/Patches.py
+++ b/pycvsanaly2/extensions/Patches.py
@@ -53,7 +53,7 @@ class PatchJob(Job):
 
         while not done and not failed:
             try:
-                self.repo.show(self.repo_uri, self.rev)
+                self.repo.show(self.repo_uri, self.rev, ignore_whitespaces=True)
                 self.data = to_utf8(unicode(to_utf8(io.getvalue()), "utf-8", errors='replace')).strip()
                 done = True
             except (CommandError, CommandRunningError) as e:


### PR DESCRIPTION
Git offers the option to ignore changes that are only based on different whitespaces (e.g. Tabs changed to 4 spaces).

With this patch only changed, that are "real" are processed by Patches, CommitLOC and HunkBlame.

This needs an update of  SoftwareIntrospectionLab/repositoryhandler#19 and SoftwareIntrospectionLab/guilty#2.
