### PR TITLE
HunkBlame: Functionality to ignore comments only lines.

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -30,6 +30,7 @@ CVSAnalY has the following dependencies:
 * Subversion (optional. Required for SVN support. Make sure to read the "SCM Support section.)
 * Git (optional. Required for Git support. Must be >= 1.7.4 for HunkBlame extension to work)
 * Python MySQLDb (optional, but of course required if you wish to actually use MySQL as your database engine!)
+* Pygments (optional. Required for extension HunkBlame with the option --hb-ignore-comments. This needs to be placed in your [PYTHONPATH][pp])
 
 ### Install
 

--- a/pycvsanaly2/Config.py
+++ b/pycvsanaly2/Config.py
@@ -63,6 +63,8 @@ class Config(object):
                                                          "CVE-\d+-\d+"],
                       # Should merge commits be analyzed.
                       'analyze_merges': False,
+                      # Should comments be ignored, when running hunk_blame?
+                      'hb_ignore_comments': False,
                      }
 
     def __init__(self):
@@ -183,6 +185,10 @@ class Config(object):
             pass
         try:
             self.analyze_merges = config.analyze_merges
+        except:
+            pass
+        try:
+            self.hb_ignore_comments = config.hb_ignore_comments
         except:
             pass
 

--- a/pycvsanaly2/extensions/HunkBlame.py
+++ b/pycvsanaly2/extensions/HunkBlame.py
@@ -78,7 +78,7 @@ class HunkBlameJob(Job):
     def __do_the_blame(self, repo, repo_uri):
         printdbg("Running HunkBlameJob for %s@%s", (self.prev_path, self.prev_rev))
 
-        self.line_types = get_line_types(repo, repo_uri, self.rev, self.path)
+        self.line_types = get_line_types(repo, repo_uri, self.prev_rev, self.prev_path)
         if self.line_types is None:
             printdbg("""No lexer (output) for %s@%s""" % (self.prev_path, self.prev_rev))
 

--- a/pycvsanaly2/extensions/HunkBlame.py
+++ b/pycvsanaly2/extensions/HunkBlame.py
@@ -38,7 +38,10 @@ class HunkBlameJob(Job):
     class BlameContentHandler(BlameJob.BlameContentHandler):
         def __init__(self, hunks, line_types):
             self.hunks = hunks
-            self.line_types = line_types
+            if line_types:
+                self.line_types = line_types
+            else:
+                self.line_types = []
             self.bug_revs = {}
 
         def line(self, blame_line):

--- a/pycvsanaly2/extensions/HunkBlame.py
+++ b/pycvsanaly2/extensions/HunkBlame.py
@@ -125,11 +125,10 @@ class HunkBlameJob(Job):
                        start=start, end=end, ignore_whitespaces=True)
             self.collect_results(out)
         except RepositoryCommandError, e:
+            printerr("Command %s returned %d (%s).", (e.cmd, e.returncode, e.error))
             self.failed = True
         p.end()
         repo.remove_watch(BLAME, wid)
-
-        return not self.failed
 
     def run(self, repo, repo_uri):
         try:

--- a/pycvsanaly2/extensions/HunkBlame.py
+++ b/pycvsanaly2/extensions/HunkBlame.py
@@ -41,6 +41,7 @@ class HunkBlameJob(Job):
             if line_types:
                 self.line_types = line_types
             else:
+                printdbg("Received empty set of line_types!")
                 self.line_types = []
             self.bug_revs = {}
 
@@ -79,8 +80,7 @@ class HunkBlameJob(Job):
 
         self.line_types = get_line_types(repo, repo_uri, self.rev, self.path)
         if self.line_types is None:
-            printerr("Skipping HunkBlameJob because no lexer output.")
-            return
+            printdbg("""No lexer (output) for %s@%s""" % (self.prev_path, self.prev_rev))
 
         def blame_line(line, p):
             p.feed(line)

--- a/pycvsanaly2/extensions/line_types.py
+++ b/pycvsanaly2/extensions/line_types.py
@@ -31,7 +31,7 @@ def _convert_linebreaks(input):
     return input.replace('\r\n', '\n').replace('\r', '\n')
 
 def _strip_lines(text):
-    """Strip every line of a strip of whitespaces."""
+    """Strip every line of whitespaces."""
 
     text_array = map(lambda s: s.strip(), text.split("\n"))
     return "\n".join(text_array)

--- a/pycvsanaly2/extensions/line_types.py
+++ b/pycvsanaly2/extensions/line_types.py
@@ -1,0 +1,124 @@
+# Copyright (C) 2011 Alexander Pepper
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+#
+# Authors :
+#       Alexander Pepper <pepper@inf.fu-berlin.de>
+
+from pygments.lexers import get_lexer_for_filename
+from pygments.util import ClassNotFound
+from repositoryhandler.backends.watchers import CAT
+from repositoryhandler.Command import CommandError, CommandRunningError
+from pycvsanaly2.utils import to_utf8, printerr, printdbg
+from io import BytesIO
+
+def _convert_linebreaks(input):
+    # source: http://code.activestate.com/recipes/435882-normalizing-newlines-between-windowsunixmacs/
+    return input.replace('\r\n', '\n').replace('\r', '\n')
+
+def _strip_lines(text):
+    text_array = map(lambda s: s.strip(), text.split("\n"))
+    return "\n".join(text_array)
+
+def _iterate_lexer_output(iterator):
+    output_lines = []
+    output_line = []
+    for ttype, value in iterator:
+        input_lines = value.split("\n")
+        for i in range(len(input_lines)):
+            item = {}
+            item["token"] = str(ttype)
+            item["value"] = to_utf8(input_lines[i]).decode("utf-8")
+            if (item["value"] != '') | (i == 0):
+                output_line.append(item)
+            if (len(input_lines) > 1) & (i < len(input_lines)-1):
+                output_lines.append(output_line)
+                output_line = []
+    return output_lines
+
+def _comment_empty_or_code(lines_array):
+    output = ""
+    for line in lines_array:
+        if (len(line) < 1):
+            output += "empty\n"
+            continue
+        first_token = line[0]["token"]
+        first_value = line[0]["value"]
+        if (len(line) == 1) & (first_token == "Token.Text") & (first_value == ""):
+            output += "empty\n"
+        elif (len(line) == 1) & ((first_token == "Token.Comment.Single") | (first_token == "Token.Comment.Multiline")):
+            output += "comment\n"
+        else:
+            output += "code\n"
+
+    return output
+
+def process_file_content(lexer, file_content):
+    if (lexer is None) | (file_content is None):
+        return None
+    # Strip Spaces and Tabs from begining and end
+    # Not shure if this should be skipped, when the language uses off-side rules (e.g. python, 
+    # see http://en.wikipedia.org/wiki/Off-side_rule for list)
+    stripped_code = _strip_lines(file_content)
+
+    lexer_output = _iterate_lexer_output(lexer.get_tokens(stripped_code))
+    return _comment_empty_or_code(lexer_output)
+
+
+def _get_file_content(repo, uri, rev):
+    def write_line(data, io):
+        io.write(data)
+
+    io = BytesIO()
+    wid = repo.add_watch(CAT, write_line, io)
+    try:
+        repo.cat(uri, rev)
+        file_content = to_utf8(io.getvalue()).decode("utf-8")
+        file_content = _convert_linebreaks(file_content) #make shure we do have the same new lines.
+    except (CommandError, CommandRunningError) as e:
+        printerr("Error running show command: %s, FAILED", (str(e),))
+        file_content = None
+
+    repo.remove_watch(CAT, wid)
+    return file_content
+
+def get_line_types(repo, repo_uri, rev, path):
+    #profiler_start("Processing LineTypes for revision %s:%s", (self.rev, self.file_path))
+    uri = repo_uri + "/" + path   # concat repo_uri and file_path for full path
+    try:
+        lexer = get_lexer_for_filename(path)
+    except(ClassNotFound) as e:
+        printerr("[process_file_content] No lexer found for " + str(path))
+        return None
+
+    file_content = _get_file_content(repo, uri, rev)  # get file_content
+    if file_content is not None:
+        line_types = process_file_content(lexer, file_content)
+        line_types = line_types.split("\n")
+    else:
+        printerr("Error: No file content for " + str(rev) + ":" + str(path) + "! Skipping.")
+        line_types = None
+
+    return line_types
+    #profiler_stop("Processing LineTypes for revision %s:%s", (self.rev, self.file_path))
+
+def line_is_code(line_types_array, line_nr):
+    try:
+        line_type = line_types_array[line_nr-1]
+    except IndexError as e:
+        printdbg("Line lexer output. Must be an empty line!")
+        line_type = None
+
+    return line_type == "code"

--- a/pycvsanaly2/extensions/line_types.py
+++ b/pycvsanaly2/extensions/line_types.py
@@ -49,8 +49,8 @@ def _get_file_content(repo, uri, rev):
         repo.cat(uri, rev)
         file_content = to_utf8(io.getvalue()).decode("utf-8")
         file_content = _convert_linebreaks(file_content) #make shure we do have the same new lines.
-    except (CommandError, CommandRunningError) as e:
-        printerr("Error running show command: %s, FAILED", (str(e),))
+    except Exception as e:
+        printerr("[get_line_types] Error running show command: %s, FAILED", (str(e),))
         file_content = None
 
     repo.remove_watch(CAT, wid)
@@ -68,9 +68,9 @@ def _iterate_lexer_output(iterator):
             item = {}
             item["token"] = str(ttype)
             item["value"] = to_utf8(input_lines[i]).decode("utf-8")
-            if (item["value"] != '') | (i == 0):
+            if (item["value"] != '') or (i == 0):
                 output_line.append(item)
-            if (len(input_lines) > 1) & (i < len(input_lines)-1):
+            if (len(input_lines) > 1) and (i < len(input_lines)-1):
                 output_lines.append(output_line)
                 output_line = []
     return output_lines

--- a/pycvsanaly2/extensions/line_types.py
+++ b/pycvsanaly2/extensions/line_types.py
@@ -106,7 +106,7 @@ def get_line_types(repo, repo_uri, rev, path):
     try:
         lexer = get_lexer_for_filename(path)
     except(ClassNotFound) as e:
-        printerr("[get_line_types] No lexer found for " + str(path))
+        printdbg("[get_line_types] No lexer found for " + str(path))
         return None
 
     file_content = _get_file_content(repo, uri, rev)  # get file_content
@@ -118,7 +118,7 @@ def get_line_types(repo, repo_uri, rev, path):
         line_types = _comment_empty_or_code(lexer_output)
         line_types = line_types.split("\n")
     else:
-        printerr("Error: No file content for " + str(rev) + ":" + str(path) + "! Skipping.")
+        printdbg("Error: No file content for " + str(rev) + ":" + str(path) + "! Skipping.")
         line_types = None
 
     return line_types

--- a/pycvsanaly2/extensions/line_types.py
+++ b/pycvsanaly2/extensions/line_types.py
@@ -24,6 +24,7 @@ from repositoryhandler.Command import CommandError, CommandRunningError
 from pycvsanaly2.utils import to_utf8, printerr, printdbg
 from io import BytesIO
 import os
+from pygments.lexers import NemerleLexer
 
 def _convert_linebreaks(input):
     """Converts all linebreaks (e.g. from windows) to one format"""
@@ -119,6 +120,11 @@ def get_line_types(repo, repo_uri, rev, path):
             except ClassNotFound:
                 printdbg("[get_line_types] No guess or lexer found for " + str(rev) + ":" + str(path) + ". Using TextLexer instead.")
                 lexer = TextLexer()
+
+        if isinstance(lexer, NemerleLexer):
+            # this lexer is broken and yield an unstoppable process
+            # see https://bitbucket.org/birkenfeld/pygments-main/issue/706/nemerle-lexer-ends-in-an-infinite-loop
+            lexer = TextLexer()
 
         # Not shure if this should be skipped, when the language uses off-side rules (e.g. python,
         # see http://en.wikipedia.org/wiki/Off-side_rule for list)

--- a/pycvsanaly2/main.py
+++ b/pycvsanaly2/main.py
@@ -88,6 +88,8 @@ Options:
                                  the on-disk cache, so will often empty it.
       --analyze-merges           Tells cvsanaly to also parse merge commits.
                                  The default is to skip them.
+      --hb-ignore-comments       Tells extension HunkBlame to ignore lines,
+                                 that only contain comments.
 
 Database:
 
@@ -219,7 +221,7 @@ def main(argv):
                  "db-database=", "db-driver=", "extensions=", "hard-order",
                  "metrics-all", "metrics-noerr", "no-content", "branch=",
                  "backout", "low-memory", "count-types=", "analyze-merges",
-                 "bugfixregexes=", "bugfixregexes-case="]
+                 "hb-ignore-comments", "bugfixregexes=", "bugfixregexes-case="]
 
     # Default options
     debug = None
@@ -244,6 +246,7 @@ def main(argv):
     backout = None
     count_types = None
     analyze_merges = None
+    hb_ignore_comments = None
     bug_fix_regexes = None
     bug_fix_regexes_case_sensitive = None
 
@@ -304,6 +307,8 @@ def main(argv):
             backout = True
         elif opt in ("--analyze-merges"):
             analyze_merges = True
+        elif opt in ("--hb-ignore-comments"):
+            hb_ignore_comments = True
         elif opt in("--bugfixregexes", ):
             bug_fix_regexes = value.split(',')
         elif opt in("--bugfixregexes-case", ):
@@ -368,6 +373,8 @@ def main(argv):
         config.extensions = get_all_extensions()
     if analyze_merges is not None:
         config.analyze_merges = analyze_merges
+    if hb_ignore_comments is not None:
+        config.hb_ignore_comments = hb_ignore_comments
     if bug_fix_regexes is not None:
         if bug_fix_regexes == ['']:
             # This is empty, it means the user didn't want to match


### PR DESCRIPTION
I wrote a bigger extension for `HunkBlame` to **not** trace lines, that only contain comments.

In order for this to work, `Pygments` needs to be installed. Also the option `--hb-ignore-comments` respectively `hb_ignore_comments` needs to be set to `True`. The default is `False`.

With this option, every file, that get's analyzed by HunkBlame is run thru a lexer of pygments and the output tokens of pygments are analyzed by line. If a line only contains empty space or a comment, `HunkBlame` will not trace the origin.

I wrote this, to increase the quality of the blamed commits. Comments usually do not modify the runtime behavior of an application.

Observations:
- With the repository of `cvsanaly` with this option 5031 hunk_blames are found. Without the option it's 5216 hunk_blames.
- With the option runtime of `HunkBlame` increases by a factor of 2 to 3 or even more. This is because for every file pygmentize needs to analyse the content.

Please provide feedback to extension of the extension `HunkBlame`.
