### PR TITLE
Bugfix for Command-Issue.

### DIFF
--- a/pycvsanaly2/Command.py
+++ b/pycvsanaly2/Command.py
@@ -188,8 +188,10 @@ class Command(object):
         def out_cb(out_chunk, out_data_l):
             out_data = out_data_l[0]
             out_data += out_chunk
-            while '\n' in out_data:
+            while len(out_data) > 0:
                 pos = out_data.find('\n')
+                if pos < 0:
+                    pos = len(out_data)
                 parser_out_func(out_data[:pos + 1])
                 out_data = out_data[pos + 1:]
             out_data_l[0] = out_data
@@ -197,8 +199,10 @@ class Command(object):
         def err_cb(err_chunk, err_data_l):
             err_data = err_data_l[0]
             err_data += err_chunk
-            while '\n' in err_data:
+            while len(err_data) > 0:
                 pos = err_data.find('\n')
+                if pos < 0:
+                    pos = len(err_data)
                 parser_error_func(err_data[:pos + 1])
                 err_data = err_data[pos + 1:]
             err_data_l[0] = err_data


### PR DESCRIPTION
The last line of files that are not in UNIX format was not read by
the 'cat' method. One of the callback functions expected a '\n'
that never appeared.

This is a copy from repositoryhandler.
Original author: Luis Cañas Díaz lcanas@libresoft.es
Bug Spotted by Alexander Pepper.
