### PR TITLE
FileTypes speedup

### DIFF
--- a/pycvsanaly2/extensions/__init__.py
+++ b/pycvsanaly2/extensions/__init__.py
@@ -81,7 +81,7 @@ from pycvsanaly2.utils import printerr
 
 
 _extensions = {}
-
+_unavailable_extensions = {}
 
 def register_extension(extension_name, extension_class):
     _extensions[extension_name] = extension_class
@@ -92,8 +92,9 @@ def get_extension(extension_name):
         try:
             __import__("pycvsanaly2.extensions.%s" % extension_name)
         except ImportError as e:
-            printerr("Error in importing extension %s: %s", 
-                     (extension_name, str(e)))
+            _unavailable_extensions[extension_name] = "missing dependency: %s" % str(e)
+#            printerr("Error in importing extension %s: %s", 
+#                     (extension_name, str(e)))
 
     if extension_name not in _extensions:
         raise ExtensionUnknownError('Extension %s not registered' % \
@@ -101,6 +102,8 @@ def get_extension(extension_name):
 
     return _extensions[extension_name]
 
+def get_unavailable_extensions():
+    return _unavailable_extensions
 
 def get_all_extensions():
     # Do something to get a list of extensions, probably like a file
@@ -111,7 +114,6 @@ def get_all_extensions():
     # script, ie. all possible extensions
     possible_file_paths = glob(os.path.realpath(os.path.dirname(__file__)) \
                                + "/*.py")
-    
     # This splitting will extract the file name from the expression.
     # The list has special Python files, like __init.py__ filtered.
     for extension in [os.path.splitext(os.path.split(fp)[1])[0] for 

--- a/pycvsanaly2/main.py
+++ b/pycvsanaly2/main.py
@@ -40,7 +40,7 @@ from Database import (create_database, TableAlreadyExists, AccessDenied,
     initialize_ids, DatabaseException)
 from DBProxyContentHandler import DBProxyContentHandler
 from Log import LogReader, LogWriter
-from extensions import get_all_extensions
+from extensions import get_all_extensions, get_unavailable_extensions
 from ExtensionsManager import (ExtensionsManager, InvalidExtension,
     InvalidDependency)
 from Config import Config, ErrorLoadingConfig
@@ -50,6 +50,21 @@ from DBDeletionHandler import DBDeletionHandler
 
 
 def usage():
+    extlist = get_all_extensions()
+    unavailableextlist = get_unavailable_extensions();
+    extensionhelp = """\n\t\t\t\t\t"""
+    for extensionname in extlist:
+      extensionhelp += extensionname+"""\n\t\t\t\t\t"""
+    
+    if len(unavailableextlist) > 0:
+      extensionhelp += """
+                                 The following extensions are not available 
+                                 due to missing dependencies:\n\n\t\t\t\t\t"""
+
+    for extensionname in unavailableextlist:
+      extensionhelp += extensionname+""" (%s) """"""\n\t\t\t\t\t""" % \
+                       unavailableextlist[extensionname].replace("No module named ","")
+      
     print "%s %s - %s" % (PACKAGE, VERSION, DESCRIPTION)
     print COPYRIGHT
     print
@@ -72,9 +87,9 @@ Options:
   -s, --save-logfile[=path]      Save the repository log to the given path
   -n, --no-parse                 Skip the parsing process. It only makes sense
                                  in conjunction with --extensions
-      --extensions=ext1,ext2,    List of extensions to run, available extensions
-                                 can be found under 'pycvsanaly2/extensions'
-                                 directory
+      --extensions=ext1,ext2,    List of extensions to run. Currently available 
+                                 extensions are:
+                                 \t"""+extensionhelp+"""
       --hard-order               Execute extensions in exactly the order given.
                                  Won't follow extension dependencies.
       --branch=[branch]          Specify local branch that should be monitored.


### PR DESCRIPTION
FileTypes was insanely slow on repositories with decent size. The reasons are:
- It gets the list of files from `action_files` joining `files`. The former is a view based on a complex `select` ruling out file changes with type 'R' but not file copies.
- Related tables are not properly indexed.

As it seems that getting the list of files from `action_files` is not necessary, I get it from `files` table instead. Indices are added to related tables as well. This speeds up the execution of that SQL from a few days to a few seconds on Eclipse JDT repository.
